### PR TITLE
expose the isFile flag for tar archive entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .project
 pubspec.lock
+build/
 packages
 test/out
 example/decode_zip.dart.js

--- a/lib/src/archive_file.dart
+++ b/lib/src/archive_file.dart
@@ -14,6 +14,7 @@ class ArchiveFile {
   int ownerId = 0;
   int groupId = 0;
   int lastModTime;
+  bool isFile = true;
   /// The crc32 checksum of the uncompressed content.
   int crc32;
   String comment;

--- a/lib/src/tar_decoder.dart
+++ b/lib/src/tar_decoder.dart
@@ -28,6 +28,7 @@ class TarDecoder {
       file.ownerId = tf.ownerId;
       file.groupId = tf.groupId;
       file.lastModTime = tf.lastModTime;
+      file.isFile = tf.isFile;
 
       archive.addFile(file);
     }

--- a/lib/src/zip/zip_file.dart
+++ b/lib/src/zip/zip_file.dart
@@ -90,4 +90,6 @@ class ZipFile {
   /// still compressed.
   List<int> _content;
   int _computedCrc32;
+
+  String toString() => filename;
 }

--- a/lib/src/zip/zip_file_header.dart
+++ b/lib/src/zip/zip_file_header.dart
@@ -85,4 +85,6 @@ class ZipFileHeader {
       }
     }
   }
+
+  String toString() => filename;
 }


### PR DESCRIPTION
This CL exposes the `isFile` information from tar file entries in the `ArchiveFile` class. I couldn't find if this info is available when decoding zip files.

Also added a few toString() methods, to help when debugging.
