### PR TITLE
Set the isFile flag correct and extract the unix permissions from zip…

### DIFF
--- a/lib/src/archive_file.dart
+++ b/lib/src/archive_file.dart
@@ -15,6 +15,9 @@ class ArchiveFile {
   int groupId = 0;
   int lastModTime;
   bool isFile = true;
+  /// The unix permissions of the file stored in base 8. Use .toRadixString(8)
+  /// to convert to the chmod format (e.g. 777).
+  int unixPermissions;
   /// The crc32 checksum of the uncompressed content.
   int crc32;
   String comment;

--- a/lib/src/zip_decoder.dart
+++ b/lib/src/zip_decoder.dart
@@ -17,6 +17,12 @@ class ZipDecoder {
     for (ZipFileHeader zfh in directory.fileHeaders) {
       ZipFile zf = zfh.file;
 
+      // The attributes are stored in base 8
+      final unixAttributes = zfh.externalFileAttributes >> 16;
+      final unixPermissions = unixAttributes & 0x1FF;
+      final isDirectory = unixAttributes & 0x7000 == 0x4000;
+      final isFile = unixAttributes & 0x3F000 == 0x8000;
+
       if (verify) {
         int computedCrc = getCrc32(zf.content);
         if (computedCrc != zf.crc32) {
@@ -26,7 +32,13 @@ class ZipDecoder {
 
       var content = zf._content != null ? zf._content : zf._rawContent;
       ArchiveFile file = new ArchiveFile(zf.filename, zf.uncompressedSize,
-                                         content, zf.compressionMethod);
+          content, zf.compressionMethod)
+        ..unixPermissions = unixPermissions;
+
+      if (isFile || isDirectory) {
+        file.isFile = isFile;
+      }
+
       file.crc32 = zf.crc32;
 
       archive.addFile(file);


### PR DESCRIPTION
… archives (only works for unix zip files). With these information you can chmod the files correctly after decompression.