### PR TITLE
zipDecoder supports isFile for win archives

### DIFF
--- a/lib/archive.dart
+++ b/lib/archive.dart
@@ -1,6 +1,5 @@
 library archive;
 
-import 'dart:io';
 import 'dart:collection';
 import 'dart:convert';
 import 'dart:typed_data';

--- a/lib/archive.dart
+++ b/lib/archive.dart
@@ -1,5 +1,6 @@
 library archive;
 
+import 'dart:io';
 import 'dart:collection';
 import 'dart:convert';
 import 'dart:typed_data';

--- a/lib/src/zip_decoder.dart
+++ b/lib/src/zip_decoder.dart
@@ -37,7 +37,7 @@ class ZipDecoder {
 
       // see https://github.com/brendan-duncan/archive/issues/21
       // UNIX systems has a creator version of 3 decimal at 1 byte offset
-      if(zfh.versionMadeBy >> 8 == 3) {
+      if (zfh.versionMadeBy >> 8 == 3) {
         final bool isDirectory = unixAttributes & 0x7000 == 0x4000;
         final bool isFile = unixAttributes & 0x3F000 == 0x8000;
         if (isFile || isDirectory) {

--- a/lib/src/zip_decoder.dart
+++ b/lib/src/zip_decoder.dart
@@ -35,8 +35,14 @@ class ZipDecoder {
           content, zf.compressionMethod)
         ..unixPermissions = unixPermissions;
 
-      if (isFile || isDirectory) {
-        file.isFile = isFile;
+      // see https://github.com/brendan-duncan/archive/issues/21
+      if(Platform.isWindows) {
+        file.isFile = !file.name.endsWith('/');
+      } else {
+        // Should this not be removed and rely only on the above check?
+        if (isFile || isDirectory) {
+          file.isFile = isFile;
+        }
       }
 
       file.crc32 = zf.crc32;

--- a/test/zip_test.dart
+++ b/test/zip_test.dart
@@ -77,11 +77,30 @@ var zipTests = [
       },
     ],
   },
-  /*{
+  {
     // created in windows XP file manager.
     'Name': "res/zip/winxp.zip",
-    'File': crossPlatform,
+    'File': [
+      {
+        'Name': 'hello',
+        'isFile': true
+      },
+      {
+        'Name': 'dir/bar',
+        'isFile': true
+      },
+      {
+        'Name': "dir/empty/",
+        'Content': [], // empty list of codeUnits - no content
+        'isFile': false
+      },
+      {
+        'Name': 'readonly',
+        'isFile': true
+      },
+    ]
   },
+  /*
   {
     // created by Zip 3.0 under Linux
     'Name': "res/zip/unix.zip",
@@ -294,6 +313,9 @@ void defineZipTests() {
           }
           if (hdr.containsKey('VerifyChecksum')) {
             expect(zipFile.verifyCrc32(), equals(hdr['VerifyChecksum']));
+          }
+          if(hdr.containsKey('isFile')) {
+            expect(archive.findFile(zipFile.filename).isFile, hdr['isFile']);
           }
         }
       });


### PR DESCRIPTION
I wrote a bit more information about it here: #21 

**Warning**: it breaks this statement:
`The library has no reliance on dart:io, so it can be used for both server and web applications.`