### PR TITLE
Exponential growth of OutputStream.

### DIFF
--- a/lib/src/util/output_stream.dart
+++ b/lib/src/util/output_stream.dart
@@ -133,7 +133,8 @@ class OutputStream {
         blockSize = required;
       }
     }
-    Uint8List newBuffer = new Uint8List(_buffer.length + blockSize);
+    int newLength = (_buffer.length + blockSize) * 2;
+    Uint8List newBuffer = new Uint8List(newLength);
     newBuffer.setRange(0, _buffer.length, _buffer);
     _buffer = newBuffer;
   }


### PR DESCRIPTION
This for example improves `TarEncoder` of about `10 MB` in `350` files from `1000 ms` to `350 ms` on VM.