### PR TITLE
Upgrade args dependency to include 1.0 versions

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 documentation: https://github.com/brendan-duncan/archive/wiki
 dependencies:
   crypto: '>=2.0.0 <3.0.0'
-  args: '>=0.13.7 <1.0.0'
+  args: '>=0.13.7 <2.0.0'
   path: '>=1.4.1 <2.0.0'
 dev_dependencies:
   browser: '<1.0.0'


### PR DESCRIPTION
The args package has a 1.0 release.  This bumps the upper bound of args to include 1.0.

This constraint is blocking me from rolling flutter to a newer version of the args package, since flutter uses both args and archive, and archive currently limits args to pre 1.0 releases.

cc @mit-mit @Hixie @tvolkert @devoncarew @kevmoo