### PR TITLE
Prepare for upcoming change to HttpRequest and HttpClientResponse

### DIFF
--- a/test/tests/pub_test_wip.dart
+++ b/test/tests/pub_test_wip.dart
@@ -50,8 +50,9 @@ downloadUrls(io.HttpClient client, List urls) async {
     var download = io.HttpClient()
         .getUrl(Uri.parse(url))
         .then((io.HttpClientRequest request) => request.close())
-        .then((io.HttpClientResponse response) =>
-            response.pipe(io.File(path + '/out/' + filename).openWrite()));
+        .then((io.HttpClientResponse response) => response
+            .cast<List<int>>()
+            .pipe(io.File(path + '/out/' + filename).openWrite()));
 
     downloads.add(download);
   }


### PR DESCRIPTION
An upcoming change to the Dart SDK will change `HttpRequest` and
`HttpClientResponse` from implementing `Stream<List<int>>` to
implementing `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

https://github.com/dart-lang/sdk/issues/36900