### PR TITLE
Adds compressionLevel parameter to ZipFileEncoder

### DIFF
--- a/lib/src/io/zip_file_encoder.dart
+++ b/lib/src/io/zip_file_encoder.dart
@@ -13,25 +13,26 @@ class ZipFileEncoder {
   static const int STORE = 0;
   static const int GZIP = 1;
 
-  void zipDirectory(Directory dir, {String filename}) {
+  void zipDirectory(Directory dir, {String filename, int level}) {
     final dirPath = dir.path;
     final zip_path = filename ?? '${dirPath}.zip';
-    create(zip_path);
-    addDirectory(dir, includeDirName: false);
+    level ??= GZIP;
+    create(zip_path, level: level);
+    addDirectory(dir, includeDirName: false, level : level);
     close();
   }
 
   void open(String zip_path) => create(zip_path);
 
-  void create(String zip_path) {
+  void create(String zip_path, {int level}) {
     this.zip_path = zip_path;
 
     _output = OutputFileStream(zip_path);
     _encoder = ZipEncoder();
-    _encoder.startEncode(_output);
+    _encoder.startEncode(_output, level: level);
   }
 
-  void addDirectory(Directory dir, {bool includeDirName = true}) {
+  void addDirectory(Directory dir, {bool includeDirName = true, int level}) {
     List files = dir.listSync(recursive: true);
     for (var file in files) {
       if (file is! File) {
@@ -41,21 +42,25 @@ class ZipFileEncoder {
       final f = file as File;
       final dir_name = path.basename(dir.path);
       final rel_path = path.relative(f.path, from: dir.path);
-      addFile(f, includeDirName ? (dir_name + '/' + rel_path) : rel_path);
+      addFile(f, includeDirName ? (dir_name + '/' + rel_path) : rel_path, level);
     }
   }
 
-  void addFile(File file, [String filename]) {
+  void addFile(File file, [String filename, int level = GZIP]) {
     var file_stream = InputFileStream.file(file);
-    var f = ArchiveFile.stream(
+    var archiveFile = ArchiveFile.stream(
         filename ?? path.basename(file.path),
         file.lengthSync(),
         file_stream);
 
-    f.lastModTime = file.lastModifiedSync().millisecondsSinceEpoch;
-    f.mode = file.statSync().mode;
+    if(level == STORE) {
+      archiveFile.compress = false;
+    }
 
-    _encoder.addFile(f);
+    archiveFile.lastModTime = file.lastModifiedSync().millisecondsSinceEpoch;
+    archiveFile.mode = file.statSync().mode;
+
+    _encoder.addFile(archiveFile);
     file_stream.close();
   }
 


### PR DESCRIPTION
Since [ZipFileEncoder](https://github.com/brendan-duncan/archive/blob/master/lib/src/io/zip_file_encoder.dart) doesn't allow to change the compression level I've added an additional parameter and forwarded the desired compression level to the internally used ZipEncoder.

I've made sure to use optional parameters to not break code that relies on the old method signature.

Additionally I'd love to reduce the API surface by making every method but zipDirectory private. Would that be okay?