### PR TITLE
Add interface for adding Archive file

### DIFF
--- a/lib/src/io/zip_file_encoder.dart
+++ b/lib/src/io/zip_file_encoder.dart
@@ -63,6 +63,10 @@ class ZipFileEncoder {
     _encoder.addFile(archiveFile);
     file_stream.close();
   }
+  
+  void addArchiveFile(ArchiveFile file){
+    _encoder.addFile(file);
+  }
 
   void close() {
     _encoder.endEncode();


### PR DESCRIPTION
because I can not add noCompress file to the zip with the private _encoder member now.

usage:

    var encoder = ZipFileEncoder();
    location = sprintf("%s/%s", [path, fileName]);
    encoder.create(location);
    encoder.addArchiveFile(ArchiveFile.noCompress(
        "metadata", 20, convert.utf8.encode("application/epub+zip")));