### PR TITLE
Add const keywords to various ZLib classes and properties

### DIFF
--- a/lib/src/zlib/_zlib_decoder_io.dart
+++ b/lib/src/zlib/_zlib_decoder_io.dart
@@ -2,10 +2,12 @@ import 'dart:io';
 import '../util/input_stream.dart';
 import 'zlib_decoder_base.dart';
 
-ZLibDecoderBase createZLibDecoder() => _ZLibDecoder();
+const platformZLibDecoder = _ZLibDecoder();
 
 /// Decompress data with the zlib format decoder.
 class _ZLibDecoder extends ZLibDecoderBase {
+  const _ZLibDecoder();
+
   @override
   List<int> decodeBytes(List<int> data, {bool verify = false}) {
     return ZLibCodec().decoder.convert(data);

--- a/lib/src/zlib/_zlib_decoder_js.dart
+++ b/lib/src/zlib/_zlib_decoder_js.dart
@@ -5,11 +5,13 @@ import '../util/input_stream.dart';
 import 'inflate.dart';
 import 'zlib_decoder_base.dart';
 
-ZLibDecoderBase createZLibDecoder() => _ZLibDecoder();
+const platformZLibDecoder = _ZLibDecoder();
 
 /// Decompress data with the zlib format decoder.
 class _ZLibDecoder extends ZLibDecoderBase {
   static const int DEFLATE = 8;
+
+  const _ZLibDecoder();
 
   @override
   List<int> decodeBytes(List<int> data, {bool verify = false}) {

--- a/lib/src/zlib/zlib_decoder_base.dart
+++ b/lib/src/zlib/zlib_decoder_base.dart
@@ -2,6 +2,8 @@ import '../util/input_stream.dart';
 
 /// Decompress data with the zlib format decoder.
 abstract class ZLibDecoderBase {
+  const ZLibDecoderBase();
+
   List<int> decodeBytes(List<int> data, {bool verify = false});
 
   List<int> decodeBuffer(InputStream input, {bool verify = false});

--- a/lib/src/zlib/zlib_decoder_stub.dart
+++ b/lib/src/zlib/zlib_decoder_stub.dart
@@ -1,4 +1,4 @@
 import 'zlib_decoder_base.dart';
 
-ZLibDecoderBase createZLibDecoder() => throw UnsupportedError(
+ZLibDecoderBase get platformZLibDecoder => throw UnsupportedError(
     'Cannot create a zlib decoder without dart:html or dart:io.');

--- a/lib/src/zlib_decoder.dart
+++ b/lib/src/zlib_decoder.dart
@@ -7,11 +7,13 @@ import 'zlib/zlib_decoder_stub.dart'
 class ZLibDecoder {
   static const int DEFLATE = 8;
 
+  const ZLibDecoder();
+
   List<int> decodeBytes(List<int> data, {bool verify = false}) {
-    return createZLibDecoder().decodeBytes(data, verify: verify);
+    return platformZLibDecoder.decodeBytes(data, verify: verify);
   }
 
   List<int> decodeBuffer(InputStream input, {bool verify = false}) {
-    return createZLibDecoder().decodeBuffer(input, verify: verify);
+    return platformZLibDecoder.decodeBuffer(input, verify: verify);
   }
 }

--- a/lib/src/zlib_encoder.dart
+++ b/lib/src/zlib_encoder.dart
@@ -7,6 +7,8 @@ import 'zlib/deflate.dart';
 class ZLibEncoder {
   static const int DEFLATE = 8;
 
+  const ZLibEncoder();
+
   List<int> encode(List<int> data, {int? level}) {
     final output = OutputStream(byteOrder: BIG_ENDIAN);
 


### PR DESCRIPTION
This allows the `ZLibEncoder` and `ZLibDecoder` classes to be instantiated at compile-time, allowing for performance improvements and simplifying usage.