### PR TITLE
Add the ability to override the timestamp encoded in a Zip file.

### DIFF
--- a/lib/src/zip_encoder.dart
+++ b/lib/src/zip_encoder.dart
@@ -34,8 +34,8 @@ class _ZipEncoderData {
   int endOfCentralDirectorySize = 0;
   List<_ZipFileData> files = [];
 
-  _ZipEncoderData(this.level) {
-    final dateTime = DateTime.now();
+  _ZipEncoderData(this.level, dateTime) {
+    dateTime = dateTime ?? DateTime.now();
     final t1 = ((dateTime.minute & 0x7) << 5) | (dateTime.second ~/ 2);
     final t2 = (dateTime.hour << 3) | (dateTime.minute >> 3);
     time = ((t2 & 0xff) << 8) | (t1 & 0xff);
@@ -52,10 +52,12 @@ class ZipEncoder {
   OutputStreamBase? _output;
 
   List<int>? encode(Archive archive,
-      {int level = Deflate.BEST_SPEED, OutputStreamBase? output}) {
+      {int level = Deflate.BEST_SPEED,
+      OutputStreamBase? output,
+      DateTime? modified}) {
     output ??= OutputStream();
 
-    startEncode(output, level: level);
+    startEncode(output, level: level, modified: modified);
     for (final file in archive.files) {
       addFile(file);
     }
@@ -68,8 +70,8 @@ class ZipEncoder {
   }
 
   void startEncode(OutputStreamBase? output,
-      {int? level = Deflate.BEST_SPEED}) {
-    _data = _ZipEncoderData(level);
+      {int? level = Deflate.BEST_SPEED, DateTime? modified}) {
+    _data = _ZipEncoderData(level, modified);
     _output = output;
   }
 

--- a/test/tests/zip_test.dart
+++ b/test/tests/zip_test.dart
@@ -310,6 +310,31 @@ void main() {
     }
   });
 
+  test('encode with timestamp', () {
+    final archive = Archive();
+    var bdata = 'some file data';
+    var bytes = Uint8List.fromList(bdata.codeUnits);
+    final name = 'somefile.txt';
+    final afile = ArchiveFile.noCompress(name, bytes.lengthInBytes, bytes);
+    archive.addFile(afile);
+
+    var zip_data = ZipEncoder()
+        .encode(archive, modified: DateTime.utc(2010, DateTime.january, 1))!;
+
+    File(p.join(testDirPath, 'out/uncompressed.zip'))
+      ..createSync(recursive: true)
+      ..writeAsBytesSync(zip_data);
+
+    var arc = ZipDecoder().decodeBytes(zip_data, verify: true);
+    expect(arc.numberOfFiles(), equals(1));
+    var arcData = arc.fileData(0);
+    expect(arcData.length, equals(bdata.length));
+    for (var i = 0; i < arcData.length; ++i) {
+      expect(arcData[i], equals(bdata.codeUnits[i]));
+    }
+    expect(arc[0].lastModTime, equals(1008795648));
+  });
+
   test('password', () {
     var file = File(p.join(testDirPath, 'res/zip/password_zipcrypto.zip'));
     var bytes = file.readAsBytesSync();


### PR DESCRIPTION
This is useful for producing Zip files that are outputs in build systems like Bazel. With Bazel's caching, deterministic outputs improve buile performance. These timestamps are one source of nondetermism harming the performance of builds. https://www.youtube.com/watch?v=XItY0LmdiFA has some more details.