### PR TITLE
[ADD] Minor optimizations

### DIFF
--- a/lib/src/io/tar_file_encoder.dart
+++ b/lib/src/io/tar_file_encoder.dart
@@ -17,8 +17,8 @@ class TarFileEncoder {
   void tarDirectory(Directory dir,
       {int compression = STORE, String? filename}) {
     final dirPath = dir.path;
-    var tar_path = filename ?? '${dirPath}.tar';
-    final tgz_path = filename ?? '${dirPath}.tar.gz';
+    var tar_path = filename ?? '$dirPath.tar';
+    final tgz_path = filename ?? '$dirPath.tar.gz';
 
     Directory temp_dir;
     if (compression == GZIP) {

--- a/lib/src/io/zip_file_encoder.dart
+++ b/lib/src/io/zip_file_encoder.dart
@@ -15,7 +15,7 @@ class ZipFileEncoder {
 
   void zipDirectory(Directory dir, {String? filename, int? level}) {
     final dirPath = dir.path;
-    final zip_path = filename ?? '${dirPath}.zip';
+    final zip_path = filename ?? '$dirPath.zip';
     level ??= GZIP;
     create(zip_path, level: level);
     addDirectory(dir, includeDirName: false, level: level);

--- a/lib/src/tar/tar_command.dart
+++ b/lib/src/tar/tar_command.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:typed_data';
 import 'package:archive/archive_io.dart';
 
 /// Print the entries in the given tar file.
@@ -6,11 +7,11 @@ void listFiles(String path) {
   final file = File(path);
   if (!file.existsSync()) fail('$path does not exist');
 
-  List<int> data = file.readAsBytesSync();
+  var data = file.readAsBytesSync();
   if (path.endsWith('tar.gz') || path.endsWith('tgz')) {
-    data = GZipDecoder().decodeBytes(data);
+    data = Uint8List.fromList(GZipDecoder().decodeBytes(data));
   } else if (path.endsWith('tar.bz2') || path.endsWith('tbz')) {
-    data = BZip2Decoder().decodeBytes(data);
+    data = Uint8List.fromList(BZip2Decoder().decodeBytes(data));
   }
 
   final tarArchive = TarDecoder();

--- a/lib/src/tar/tar_command.dart
+++ b/lib/src/tar/tar_command.dart
@@ -4,7 +4,7 @@ import 'package:archive/archive_io.dart';
 /// Print the entries in the given tar file.
 void listFiles(String path) {
   final file = File(path);
-  if (!file.existsSync()) fail('${path} does not exist');
+  if (!file.existsSync()) fail('$path does not exist');
 
   List<int> data = file.readAsBytesSync();
   if (path.endsWith('tar.gz') || path.endsWith('tgz')) {
@@ -14,12 +14,11 @@ void listFiles(String path) {
   }
 
   final tarArchive = TarDecoder();
-  // Tell the decoder not to store the actual file data since we don't need
-  // it.
+  // Tell the decoder not to store the actual file data since we don't need it.
   tarArchive.decodeBytes(data, storeData: false);
 
   print('${tarArchive.files.length} file(s)');
-  tarArchive.files.forEach((f) => print('  ${f}'));
+  tarArchive.files.forEach((f) => print('  $f'));
 }
 
 /// Extract the entries in the given tar file to a directory.
@@ -27,7 +26,8 @@ Directory extractFiles(String inputPath, String outputPath) {
   Directory? temp_dir;
   var tar_path = inputPath;
 
-  if (inputPath.endsWith('tar.gz') || inputPath.endsWith('tgz')) {
+  if (inputPath.endsWith('tar.gz') || inputPath.endsWith('tgz')
+      || inputPath.endsWith('cbt')) {
     temp_dir = Directory.systemTemp.createTempSync('dart_archive');
     tar_path = '${temp_dir.path}${Platform.pathSeparator}temp.tar';
     final input = InputFileStream(inputPath);

--- a/lib/src/tar/tar_file.dart
+++ b/lib/src/tar/tar_file.dart
@@ -99,7 +99,7 @@ class TarFile {
     if (isFile && fileSize > 0) {
       final remainder = fileSize & 0x1ff; // remainder = fileSize % 512
       if (remainder != 0) {
-        final skiplen = remainder ^ 0x200;  // skiplen = remainder - 512
+        final skiplen = remainder ^ 0x200;  // skiplen = remainder % 512
         input.skip(skiplen);
       }
     }

--- a/lib/src/tar_decoder.dart
+++ b/lib/src/tar_decoder.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'tar/tar_file.dart';
 import 'util/input_stream.dart';
 import 'archive.dart';
@@ -7,7 +9,7 @@ import 'archive_file.dart';
 class TarDecoder {
   List<TarFile> files = [];
 
-  Archive decodeBytes(List<int> data,
+  Archive decodeBytes(Uint8List data,
       {bool verify = false, bool storeData = true}) {
     return decodeBuffer(InputStream(data),
         verify: verify, storeData: storeData);

--- a/lib/src/tar_decoder.dart
+++ b/lib/src/tar_decoder.dart
@@ -38,12 +38,10 @@ class TarDecoder {
       // In POSIX formatted tar files, a separate 'PAX' file contains extended
       // metadata for files. These are identified by having a type flag 'X'.
       // TODO: parse these metadata values.
-      if (tf.typeFlag == TarFile.TYPE_G_EX_HEADER ||
-          tf.typeFlag == TarFile.TYPE_G_EX_HEADER2) {
+      if (tf.typeFlag.toLowerCase() == TarFile.TYPE_G_EX_HEADER) {
         // TODO handle PAX global header.
       }
-      if (tf.typeFlag == TarFile.TYPE_EX_HEADER ||
-          tf.typeFlag == TarFile.TYPE_EX_HEADER2) {
+      if (tf.typeFlag.toLowerCase() == TarFile.TYPE_EX_HEADER) {
         //paxHeader = tf;
       } else {
         files.add(tf);

--- a/lib/src/tar_encoder.dart
+++ b/lib/src/tar_encoder.dart
@@ -6,7 +6,7 @@ import 'archive_file.dart';
 
 /// Encode an [Archive] object into a tar formatted buffer.
 class TarEncoder {
-  List<int> encode(Archive archive) {
+  Uint8List encode(Archive archive) {
     final output_stream = OutputStream();
     start(output_stream);
 
@@ -16,7 +16,7 @@ class TarEncoder {
 
     finish();
 
-    return output_stream.getBytes();
+    return Uint8List.fromList(output_stream.getBytes());
   }
 
   void start([dynamic output_stream]) {

--- a/lib/src/zlib/inflate.dart
+++ b/lib/src/zlib/inflate.dart
@@ -77,8 +77,8 @@ class Inflate {
   }
 
   /// Get the decompressed data.
-  Uint8List getBytes() {
-    return output.getBytes() as Uint8List;
+  List<int> getBytes() {
+    return output.getBytes() as List<int>;
   }
 
   void _inflate() {

--- a/lib/src/zlib/inflate.dart
+++ b/lib/src/zlib/inflate.dart
@@ -77,8 +77,8 @@ class Inflate {
   }
 
   /// Get the decompressed data.
-  List<int> getBytes() {
-    return output.getBytes() as List<int>;
+  Uint8List getBytes() {
+    return output.getBytes() as Uint8List;
   }
 
   void _inflate() {

--- a/test/tests/pub_test_wip.dart
+++ b/test/tests/pub_test_wip.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:archive/archive.dart';
 import 'package:test/test.dart';
@@ -79,7 +80,7 @@ void extractDart(List<String> urls) {
     final data = fp.readAsBytesSync();
 
     final tarArchive = TarDecoder();
-    tarArchive.decodeBytes(GZipDecoder().decodeBytes(data));
+    tarArchive.decodeBytes(Uint8List.fromList(GZipDecoder().decodeBytes(data)));
 
     print('EXTRACTING $filename');
 

--- a/test/tests/tar_test.dart
+++ b/test/tests/tar_test.dart
@@ -201,9 +201,9 @@ void main() {
 
   test('decode test2.tar.gz', () {
     var file = File(p.join(testDirPath, 'res/test2.tar.gz'));
-    List<int> bytes = file.readAsBytesSync();
+    var bytes = file.readAsBytesSync();
 
-    bytes = GZipDecoder().decodeBytes(bytes, verify: true);
+    bytes = Uint8List.fromList(GZipDecoder().decodeBytes(bytes, verify: true));
     final archive = tar.decodeBytes(bytes, verify: true);
 
     final expected_files = <File>[];

--- a/test/tests/tar_test.dart
+++ b/test/tests/tar_test.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:typed_data';
 import 'package:archive/archive.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
@@ -150,7 +151,7 @@ void main() {
 
   test('tar invalid archive', () {
     try {
-      TarDecoder().decodeBytes([1, 2, 3]);
+      TarDecoder().decodeBytes(Uint8List.fromList([1, 2, 3]));
       assert(false);
     } catch (e) {
       // pass
@@ -167,17 +168,20 @@ void main() {
     final archive = tar.decodeBytes(bytes, verify: true);
 
     expect(archive.numberOfFiles(), equals(1));
-    var x = '';
+    var x = Uint8List(0);
     for (var i = 0; i < 150; ++i) {
-      x += 'x';
+      x.add(120); // 120 = 'x'
     }
-    x += '.txt';
+    x.add(46); // x += '.txt';
+    x.add(116);
+    x.add(120);
+    x.add(116);
     expect(archive.files[0].name, equals(x));
   });
 
   test('symlink', () {
     var file = File(p.join(testDirPath, 'res/tar/symlink_tar.tar'));
-    List<int> bytes = file.readAsBytesSync();
+    var bytes = file.readAsBytesSync();
     final archive = tar.decodeBytes(bytes, verify: true);
     expect(archive.numberOfFiles(), equals(4));
     expect(archive.files[1].isSymbolicLink, equals(true));
@@ -186,7 +190,7 @@ void main() {
 
   test('decode test2.tar', () {
     var file = File(p.join(testDirPath, 'res/test2.tar'));
-    List<int> bytes = file.readAsBytesSync();
+    var bytes = file.readAsBytesSync();
     final archive = tar.decodeBytes(bytes, verify: true);
 
     final expected_files = <File>[];
@@ -212,10 +216,10 @@ void main() {
     final a_bytes = a_txt.codeUnits;
 
     var b = File(p.join(testDirPath, 'res/cat.jpg'));
-    List<int> b_bytes = b.readAsBytesSync();
+    var b_bytes = b.readAsBytesSync();
 
     var file = File(p.join(testDirPath, 'res/test.tar'));
-    List<int> bytes = file.readAsBytesSync();
+    var bytes = file.readAsBytesSync();
 
     final archive = tar.decodeBytes(bytes, verify: true);
     expect(archive.numberOfFiles(), equals(2));


### PR DESCRIPTION
* used Uint8List (see NB)
* added .cbt extension (tar file in reality)
* using AND 0x1FF instead of modulo 512 (more efficient, no risk since value > 0)
* using XOR 0x200 instead of minus (no risk since value < 512)
* slightly Improved doc for checksum
* used toLower for `TYPE_G_EX_HEADER` and `TYPE_EX_HEADER` (well they don't seem to be supported)

NB: I have not done any test for  List<int> to Uint8List, however it should be this way - unless we are handling 4 bytes by 4 bytes - as everything indicate that bytes are processed 1 by 1.

PS: Any reason why .rar decoder/encoder is not part of this excellent package? https://github.com/pmachapman/unrar/blob/master/headers.cpp