### PR TITLE
accept long filenames that are not null-terminated

### DIFF
--- a/lib/src/util/input_stream.dart
+++ b/lib/src/util/input_stream.dart
@@ -192,13 +192,13 @@ class InputStream extends InputStreamBase {
       while (!isEOS) {
         final c = readByte();
         if (c == 0) {
-          return utf8
-              ? Utf8Decoder().convert(codes)
-              : String.fromCharCodes(codes);
+          break;
         }
         codes.add(c);
       }
-      throw ArchiveException('EOF reached without finding string terminator');
+      return utf8
+          ? Utf8Decoder().convert(codes)
+          : String.fromCharCodes(codes);
     }
 
     final s = readBytes(size);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,5 +12,6 @@ dependencies:
   path: ^1.8.0
 
 dev_dependencies:
+  http: ^0.13.3
   lints: ^1.0.0
   test: ^1.17.0

--- a/test/tests/tar_test.dart
+++ b/test/tests/tar_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'package:archive/archive.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
+import 'package:http/http.dart' as http;
 
 import 'test_utils.dart';
 
@@ -173,6 +174,15 @@ void main() {
     }
     x += '.txt';
     expect(archive.files[0].name, equals(x));
+  });
+
+  test('long file name not null terminated', () async {
+    final bytes = await http.readBytes(Uri.parse('https://pub.dev/packages/firebase_messaging/versions/10.0.8.tar.gz'));
+    final tarBytes = GZipDecoder().decodeBytes(bytes, verify: true);
+    final archive = tar.decodeBytes(tarBytes, verify: true);
+
+    expect(archive.numberOfFiles(), equals(129));
+    expect(archive.files[13].name, equals('android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingBackgroundExecutor.java'));
   });
 
   test('symlink', () {


### PR DESCRIPTION
instead of throwing an exception, just read until end of stream and return the built string

fixes #166