### PR TITLE
When adding a file, remove the file from the archive first, if it already exists

### DIFF
--- a/lib/src/archive.dart
+++ b/lib/src/archive.dart
@@ -11,6 +11,7 @@ class Archive extends IterableBase<ArchiveFile> {
 
   /// Add a file to the archive.
   void addFile(ArchiveFile file) {
+    files.removeWhere((element) => element.name == file.name);
     files.add(file);
   }
 


### PR DESCRIPTION
While stumbling upon the same problem as https://github.com/brendan-duncan/archive/issues/109, this PR fixes the problem at least for me.

**Problematic code**
```dart
// Read existing archive file which already contains a file "test"
Uint8List zipBytes = File(file.path).readAsBytesSync();
Archive archive = ZipDecoder().decodeBytes(zipBytes);

// !! --> This line would lead to a duplicate of the file "test" in the archive
archive.addFile(ArchiveFile("test", testBytes.length, testBytes));

// Write archive to disk
final List<int>? zipData = ZipEncoder().encode(archive);
file.writeAsBytesSync(zipData!);
```

The zip, tested on linux, would contain the same file twice since a file with the same name can be added multiple times to the `files` property of an `Archive`. 
By simply removing any items with the same name first, it will prevent a duplicate file in the same archive but instead "update" the existing one.

I've not skimmed through the whole code but if it goes into the right direction I can add a test so the change could be merged.