### PR TITLE
set language encoding bit in the general purpose bit flag for utf8 filename encoding

### DIFF
--- a/lib/src/zip_encoder.dart
+++ b/lib/src/zip_encoder.dart
@@ -51,6 +51,9 @@ class ZipEncoder {
   late _ZipEncoderData _data;
   OutputStreamBase? _output;
 
+  /// Bit 11 of the general purpose flag, Language encoding flag
+  final int LANGAUGE_ENCODING_BIT_UTF8 = 2048;
+
   List<int>? encode(Archive archive,
       {int level = Deflate.BEST_SPEED,
       OutputStreamBase? output,
@@ -172,7 +175,7 @@ class ZipEncoder {
     output.writeUint32(ZipFile.SIGNATURE);
 
     final version = VERSION;
-    final flags = 0;
+    final flags = LANGAUGE_ENCODING_BIT_UTF8;
     final compressionMethod =
         fileData.compress ? ZipFile.DEFLATE : ZipFile.STORE;
     final lastModFileTime = fileData.time;


### PR DESCRIPTION
Currently the filenames and comments are UTF8 encoded by default but many apps (especially on Windows) don't recognize this as the language encoding bit (bit11) of the general purpose bit flag is not set.

From the ZIP Specification, section 4.4.4:
Bit 11: Language encoding flag (EFS).  If this bit is set, the filename and comment fields for this file MUST be encoded using UTF-8. (see APPENDIX D)

After setting this flag the filenames have been decoded correctly on Windows systems (tested using the integrated windows zip program and 7zip).

Note: the ZipDecoder currently does not check the general purpose bit 11 for utf8 encoding and assumes utf8 by default. The specification says in Appendix D: D.2 If general purpose bit 11 is unset, the file name and comment SHOULD conform 
to the original ZIP character encoding.
However, I think that changing this would impact all already created ZIP files with this library and we should keep it as is.
 