### PR TITLE
Fixes Password Protected Zips with directories inside (#83, #162)

### DIFF
--- a/lib/src/zip/zip_file.dart
+++ b/lib/src/zip/zip_file.dart
@@ -84,9 +84,14 @@ class ZipFile {
   List<int> get content {
     if (_content == null) {
       if (_isEncrypted) {
-        _rawContent = _decodeRawContent(_rawContent);
-        _isEncrypted = false;
-      }
+        if(_rawContent.length <= 0){
+          _content = _rawContent.toUint8List();
+          _isEncrypted = false;
+        }else{
+          _rawContent = _decodeRawContent(_rawContent);
+          _isEncrypted = false;
+        }
+     }
 
       if (compressionMethod == DEFLATE) {
         _content = Inflate.buffer(_rawContent, uncompressedSize).getBytes();


### PR DESCRIPTION
Fixes #83  and Fixes #162

Just implemented based on this and it works now with standard PkZip passwords and directories.
https://github.com/brendan-duncan/archive/issues/83#issuecomment-922493222


Credit to https://github.com/ahmadkhedr