### PR TITLE
Add `level` parameter to `tarDirectory`

### DIFF
--- a/lib/src/io/tar_file_encoder.dart
+++ b/lib/src/io/tar_file_encoder.dart
@@ -16,8 +16,13 @@ class TarFileEncoder {
   static const int STORE = 0;
   static const int GZIP = 1;
 
-  void tarDirectory(Directory dir,
-      {int compression = STORE, String? filename, bool followLinks = true}) {
+  void tarDirectory(
+    Directory dir, {
+    int compression = STORE,
+    String? filename,
+    bool followLinks = true,
+    int? level,
+  }) {
     final dirPath = dir.path;
     var tar_path = filename ?? '$dirPath.tar';
     final tgz_path = filename ?? '$dirPath.tar.gz';
@@ -36,7 +41,7 @@ class TarFileEncoder {
     if (compression == GZIP) {
       final input = InputFileStream(tar_path);
       final output = OutputFileStream(tgz_path);
-      GZipEncoder().encode(input, output: output);
+      GZipEncoder().encode(input, output: output, level: level);
       input.close();
       File(input.path).deleteSync();
     }


### PR DESCRIPTION
As said in the title. Just adding consistency across methods.