### PR TITLE
enable github actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,32 @@
+name: Dart CI
+
+on:
+  schedule:
+    # “At 00:00 (UTC) on Sunday.”
+    - cron: '0 0 * * 0'
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    container:
+      image:  google/dart:dev
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: pub get
+        run: pub get
+
+      # - name: dart format
+      #   run: dart format --output=none --set-exit-if-changed .
+
+      - name: dart analyze
+        run: dart analyze --fatal-infos
+
+      - name: dart test
+        run: dart test

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,17 +1,19 @@
 include: package:lints/recommended.yaml
 
-linter:
-  rules:
-    - camel_case_types
-
 analyzer:
+  strong-mode:
+    implicit-casts: false
+    implicit-dynamic: false
   errors:
+    constant_identifier_names: ignore
+    non_constant_identifier_names: ignore
     unused_element: error
     unused_field: error
     unused_local_variable: error
   exclude:
-    - test/res/**
-    - test/out/**
-  strong-mode:
-    implicit-casts: false
-    implicit-dynamic: false
+    - test/tests/res/**
+    - test/tests/out/**
+
+linter:
+  rules:
+    - camel_case_types


### PR DESCRIPTION
- enable github actions for this repo
- fix https://github.com/brendan-duncan/archive/issues/194

This config is a bit prescriptive; it can be tweaked depending on what you want. Right now it'll fail on any analysis issue - even an info level issue. It does not fail on any formatting differences (there are a few existing differences in the repo), and it auto-runs the CI weekly (and on every PR, and every commit to master).
