### PR TITLE
fix the tar decoder to support the pax format

### DIFF
--- a/lib/src/tar_decoder.dart
+++ b/lib/src/tar_decoder.dart
@@ -3,6 +3,8 @@ import 'util/input_stream.dart';
 import 'archive.dart';
 import 'archive_file.dart';
 
+final paxRecordRegexp = RegExp(r"(\d+) (\w+)=(.*)");
+
 /// Decode a tar formatted buffer into an [Archive] object.
 class TarDecoder {
   List<TarFile> files = [];
@@ -19,6 +21,7 @@ class TarDecoder {
     files.clear();
 
     String? nextName;
+    String? nextLinkName;
 
     // TarFile paxHeader = null;
     while (!input.isEOS) {
@@ -41,28 +44,55 @@ class TarDecoder {
       if (tf.typeFlag == TarFile.TYPE_G_EX_HEADER ||
           tf.typeFlag == TarFile.TYPE_G_EX_HEADER2) {
         // TODO handle PAX global header.
+        continue;
       }
       if (tf.typeFlag == TarFile.TYPE_EX_HEADER ||
           tf.typeFlag == TarFile.TYPE_EX_HEADER2) {
-        //paxHeader = tf;
-      } else {
-        files.add(tf);
+        tf.rawContent!
+            .readString()
+            .split('\n')
+            .where((s) => paxRecordRegexp.hasMatch(s))
+            .forEach((record) {
+          print('Record: $record');
+          var match = paxRecordRegexp.firstMatch(record)!;
+          var keyword = match.group(2);
+          var value = match.group(3)!;
+          switch (keyword) {
+            case 'path':
+              nextName = value;
+              break;
+            case 'linkpath':
+              nextLinkName = value;
+              break;
+            default:
+            // TODO: support other pax headers.
+          }
+        });
+        continue;
+      }
 
-        final file =
-            ArchiveFile(nextName ?? tf.filename, tf.fileSize, tf.rawContent);
-
-        file.mode = tf.mode;
-        file.ownerId = tf.ownerId;
-        file.groupId = tf.groupId;
-        file.lastModTime = tf.lastModTime;
-        file.isFile = tf.isFile;
-        file.isSymbolicLink = tf.typeFlag == TarFile.TYPE_SYMBOLIC_LINK;
-        file.nameOfLinkedFile = tf.nameOfLinkedFile;
-
-        archive.addFile(file);
-
+      // Fix file attributes.
+      if (nextName != null) {
+        tf.filename = nextName!;
         nextName = null;
       }
+      if (nextLinkName != null) {
+        tf.nameOfLinkedFile = nextLinkName!;
+        nextLinkName = null;
+      }
+      files.add(tf);
+
+      final file = ArchiveFile(tf.filename, tf.fileSize, tf.rawContent);
+
+      file.mode = tf.mode;
+      file.ownerId = tf.ownerId;
+      file.groupId = tf.groupId;
+      file.lastModTime = tf.lastModTime;
+      file.isFile = tf.isFile;
+      file.isSymbolicLink = tf.typeFlag == TarFile.TYPE_SYMBOLIC_LINK;
+      file.nameOfLinkedFile = tf.nameOfLinkedFile;
+
+      archive.addFile(file);
     }
 
     return archive;

--- a/test/tests/tar_test.dart
+++ b/test/tests/tar_test.dart
@@ -92,7 +92,7 @@ var tarTests = [
       },
     ],
   },
-  /*{
+  {
     'file': 'res/tar/pax.tar',
     'headers': [
       {
@@ -123,7 +123,7 @@ var tarTests = [
         'Linkname':   '123456789101112131415161718192021222324252627282930313233343536373839404142434445464748495051525354555657585960616263646566676869707172737475767778798081828384858687888990919293949596979899100',
       },
     ],
-  },*/
+  },
   {
     'file': 'res/tar/nil-uid.tar',
     'headers': [
@@ -287,6 +287,9 @@ void main() {
         }
         if (hdr.containsKey('Size')) {
           expect(file.fileSize, equals(hdr['Size']));
+        }
+        if (hdr.containsKey('Linkname')) {
+          expect(file.nameOfLinkedFile, equals(hdr['Linkname']));
         }
         if (hdr.containsKey('ModTime')) {
           expect(file.lastModTime, equals(hdr['ModTime']));


### PR DESCRIPTION
- fix the tar decoder to support the pax format

This patches the tar decoder to handle the pax format. For context, in python 3.8, tar archive format has changed; see [make_archive](https://docs.python.org/3/library/shutil.html#shutil.make_archive).

> Changed in version 3.8: The modern pax (POSIX.1-2001) format is now used instead of the legacy GNU format for archives created with format="tar".

cc @emmanuel-p
