### PR TITLE
Tar pax format: support non-null terminated pax headers

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -16,4 +16,5 @@ analyzer:
 
 linter:
   rules:
+    - avoid_print
     - camel_case_types

--- a/lib/src/tar/tar_command.dart
+++ b/lib/src/tar/tar_command.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: avoid_print
+
 import 'dart:io';
 import 'package:archive/archive_io.dart';
 

--- a/lib/src/tar_decoder.dart
+++ b/lib/src/tar_decoder.dart
@@ -1,7 +1,9 @@
-import 'tar/tar_file.dart';
-import 'util/input_stream.dart';
+import 'dart:convert';
+
 import 'archive.dart';
 import 'archive_file.dart';
+import 'tar/tar_file.dart';
+import 'util/input_stream.dart';
 
 final paxRecordRegexp = RegExp(r"(\d+) (\w+)=(.*)");
 
@@ -48,12 +50,11 @@ class TarDecoder {
       }
       if (tf.typeFlag == TarFile.TYPE_EX_HEADER ||
           tf.typeFlag == TarFile.TYPE_EX_HEADER2) {
-        tf.rawContent!
-            .readString()
+        utf8
+            .decode(tf.rawContent!.toUint8List())
             .split('\n')
             .where((s) => paxRecordRegexp.hasMatch(s))
             .forEach((record) {
-          print('Record: $record');
           var match = paxRecordRegexp.firstMatch(record)!;
           var keyword = match.group(2);
           var value = match.group(3)!;

--- a/test/tests/io_test.dart
+++ b/test/tests/io_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: avoid_print
+
 import 'dart:io';
 import 'dart:typed_data';
 
@@ -217,7 +219,8 @@ void main() {
   test('tarDirectory', () {
     // Encode a directory from disk to disk, no memory
     final encoder = TarFileEncoder();
-    encoder.tarDirectory(Directory('$testDirPath/res/test2'), filename: '$testDirPath/out/example2.tgz', compression:1);
+    encoder.tarDirectory(Directory('$testDirPath/res/test2'),
+        filename: '$testDirPath/out/example2.tgz', compression: 1);
     encoder.close();
   });
 

--- a/test/tests/pub_test_wip.dart
+++ b/test/tests/pub_test_wip.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: avoid_print
+
 import 'dart:io';
 
 import 'package:archive/archive.dart';

--- a/web/test_zip.dart
+++ b/web/test_zip.dart
@@ -1,5 +1,8 @@
+// ignore_for_file: avoid_print
+
 import 'dart:html';
 import 'dart:typed_data';
+
 import 'package:archive/archive.dart';
 
 void main() {


### PR DESCRIPTION
Last PR for a bit :) This is to support non-null terminated pax headers for the tar pax format.

- tar pax format: support non-null terminated pax headers
- remove a spurious print statement
- add a lint so that print statements can't creep into package code

cc @emmanuel-p
