### PR TITLE
Fix ZIP64 extra field reading issue.

### DIFF
--- a/lib/src/zip/zip_file_header.dart
+++ b/lib/src/zip/zip_file_header.dart
@@ -48,11 +48,22 @@ class ZipFileHeader {
       if (extraLen > 0) {
         final extra = input.readBytes(extraLen);
         extraField = extra.toUint8List();
+        // Rewind to start of the extra fields to read field by field.
+        extra.rewind(extraLen);
 
         final id = extra.readUint16();
-        final size = extra.readUint16();
+        var size = extra.readUint16();
         if (id == 1) {
           // Zip64 extended information
+          // The following is the layout of the zip64 extended
+          // information "extra" block. If one of the size or
+          // offset fields in the Local or Central directory
+          // record is too small to hold the required data,
+          // a Zip64 extended information record is created.
+          // The order of the fields in the zip64 extended
+          // information record is fixed, but the fields MUST
+          // only appear if the corresponding Local or Central
+          // directory record field is set to 0xFFFF or 0xFFFFFFFF.
           // Original
           // Size       8 bytes    Original uncompressed file size
           // Compressed
@@ -62,17 +73,21 @@ class ZipFileHeader {
           // Disk Start
           // Number     4 bytes    Number of the disk on which
           // this file starts
-          if (size >= 8) {
+          if (size >= 8 && uncompressedSize == 0xFFFFFFFF) {
             uncompressedSize = extra.readUint64();
+            size -= 8;
           }
-          if (size >= 16) {
+          if (size >= 8 && compressedSize == 0xFFFFFFFF) {
             compressedSize = extra.readUint64();
+            size -= 8;
           }
-          if (size >= 24) {
+          if (size >= 8 && localHeaderOffset == 0xFFFFFFFF) {
             localHeaderOffset = extra.readUint64();
+            size -= 8;
           }
-          if (size >= 28) {
+          if (size >= 4 && diskNumberStart == 0xFFFF) {
             diskNumberStart = extra.readUint32();
+            size -= 4;
           }
         }
       }


### PR DESCRIPTION
Hi team, I found an issue reading file entry in ZIP64 field. 

After reading the [zip format document](https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT), I found that the extra fields are though optional, but defined by original basic field is equal to 0xFFFFFFFF.

So I changed the code to fullfil the protocol.