### PR TITLE
Fix `ArchiveFile.writeContent` to unwrap `FileContent`

### DIFF
--- a/lib/src/archive_file.dart
+++ b/lib/src/archive_file.dart
@@ -108,6 +108,9 @@ class ArchiveFile {
   }
 
   void writeContent(OutputStreamBase output, {bool freeMemory = true}) {
+    if (_content is FileContent) {
+      _content = _content.content;
+    }
     if (_content is List<int>) {
       output.writeBytes(_content as List<int>);
     } else if (_content is InputStreamBase) {


### PR DESCRIPTION
Currently, `writeContent` does not write any content for `ArchiveFile`s that have been created with `FileContent` (such as from `ZipDecoder`), if `content` has not been accessed previously.