### PR TITLE
feat: add af.lastModTime

### DIFF
--- a/lib/src/io/zip_file_encoder.dart
+++ b/lib/src/io/zip_file_encoder.dart
@@ -51,6 +51,7 @@ class ZipFileEncoder {
         filename = includeDirName ? (dirName + '/' + filename) : filename;
         final af = ArchiveFile(filename + '/', 0, null);
         af.mode = file.statSync().mode;
+        af.lastModTime = file.statSync().modified.millisecondsSinceEpoch ~/ 1000;
         af.isFile = false;
         _encoder.addFile(af);
       } else if (file is File) {


### PR DESCRIPTION
use statSync().modified to replace af's lastModTime
 it can ensure that the modification time of the folder is not the current time
 Ensure that the contents of the compressed zip file md5 are the same