### PR TITLE
Assume isFile=true if type is 0x0000

### DIFF
--- a/lib/src/zip_decoder.dart
+++ b/lib/src/zip_decoder.dart
@@ -16,8 +16,11 @@ class ZipDecoder {
     return decodeBuffer(InputStream(data), verify: verify, password: password);
   }
 
-  Archive decodeBuffer(InputStreamBase input,
-      {bool verify = false, String? password}) {
+  Archive decodeBuffer(
+    InputStreamBase input, {
+    bool verify = false,
+    String? password,
+  }) {
     directory = ZipDirectory.read(input, password: password);
     final archive = Archive();
 
@@ -49,6 +52,7 @@ class ZipDecoder {
         final fileType = file.mode & 0xF000;
         switch (fileType) {
           case 0x8000:
+          case 0x0000: // No determination can be made so we assume it's a file.
             file.isFile = true;
             break;
           case 0xA000:


### PR DESCRIPTION
Not entirely sure if this is the correct solution, but some archives ([example: protobuf release zip](https://github.com/protocolbuffers/protobuf/releases/download/v21.10/protoc-21.10-linux-x86_64.zip)) have their entries file type bits set to `0`. Meaning `isFile = false` even though it should be true (at least in case of the protobuf zip).

Let me know if this is the correct solution.