### PR TITLE
Fix long path name tar encoding and decoding errors

### DIFF
--- a/lib/src/tar_decoder.dart
+++ b/lib/src/tar_decoder.dart
@@ -36,7 +36,11 @@ class TarDecoder {
       final tf = TarFile.read(input, storeData: storeData);
       // GNU tar puts filenames in files when they exceed tar's native length.
       if (tf.filename == '././@LongLink') {
-        nextName = tf.rawContent!.readString();
+        try {
+          nextName = tf.rawContent!.readString();
+        } catch (error) {
+          nextName = tf.rawContent!.readString(size: tf.fileSize);
+        }
         continue;
       }
 

--- a/test/tests/tar_test.dart
+++ b/test/tests/tar_test.dart
@@ -1,5 +1,5 @@
 import 'dart:io';
-import 'package:archive/archive.dart';
+import 'package:archive/archive_io.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 import 'package:http/http.dart' as http;
@@ -180,6 +180,18 @@ void main() {
     }
     x += '.txt';
     expect(archive.files[0].name, equals(x));
+  });
+
+  test('long file name encode & decode', () {
+    const kLongFileName = '/long_path_name/long_path_name/long_path_name/long_path_name/to/this_is_an_extremely_long_filename.bin';
+    const kFilePath = 'output.tar';
+    final archive = Archive()..addFile(ArchiveFile(kLongFileName, 1, [1]));
+    try {
+      TarEncoder().encode(archive, output: OutputFileStream(kFilePath));
+      TarDecoder().decodeBuffer(InputFileStream(kFilePath));
+    } finally {
+      File(kFilePath).deleteSync();
+    }
   });
 
   test('long file name not null terminated', () async {


### PR DESCRIPTION
`FormatException: EOF reached without finding string terminator` will be thrown with using the InputFileStream / OutputFileStream for  `.tar` file's encoding and decoding, if any file's path name is very very long.

**Minimum Reproducible Example**
```dart
import 'package:archive/archive_io.dart';  
  
void main() async {  
  const kLongFileName = '/long_path_name/long_path_name/long_path_name/long_path_name/to/this_is_an_extremely_long_filename.bin';  
  
  {  
    final archive = Archive()..addFile(ArchiveFile(kLongFileName, 1, [1]));  
    final bytes = TarEncoder().encode(archive);  
    TarDecoder().decodeBytes(bytes);  
  }  
  
  {  
    final archive = Archive()..addFile(ArchiveFile(kLongFileName, 1, [1]));  
    final outputFile = 'output.tar';  
    TarEncoder().encode(archive, output: OutputFileStream(outputFile));  
    TarDecoder().decodeBuffer(InputFileStream(outputFile)); // FormatException: EOF reached without finding string terminator  
  }  
}
```


**How to Fix**
In order to control the scope of influence (such as anywhere reading a null-terminated string), pass the size parameter to the `InputStream#readString` method only when failed to trying to read the null terminator.

```bash
       if (tf.filename == '././@LongLink') {
-        nextName = tf.rawContent!.readString();
+        try {
+          nextName = tf.rawContent!.readString();
+        } catch (error) {
+          nextName = tf.rawContent!.readString(size: tf.fileSize);
+        }
         continue;
       }
```

