### PR TITLE
fix: add a listener interface to ZipDecoder to deal with large files

### DIFF
--- a/lib/src/archive.dart
+++ b/lib/src/archive.dart
@@ -86,3 +86,6 @@ class Archive extends IterableBase<ArchiveFile> {
   @override
   Iterator<ArchiveFile> get iterator => files.iterator;
 }
+
+/// FnArchiveFile is the callback invoked when the zip decoder iterates through the archive.
+typedef FnArchiveFile = void Function(ArchiveFile file);

--- a/lib/src/zip_decoder.dart
+++ b/lib/src/zip_decoder.dart
@@ -21,8 +21,20 @@ class ZipDecoder {
     bool verify = false,
     String? password,
   }) {
-    directory = ZipDirectory.read(input, password: password);
     final archive = Archive();
+    onDecodeBuffer(input, (ArchiveFile file) {
+      archive.addFile(file);
+    }, verify: verify, password: password);
+    return archive;
+  }
+
+  void onDecodeBuffer(
+    InputStreamBase input,
+    FnArchiveFile fnArchiveFile, {
+    bool verify = false,
+    String? password,
+  }) {
+    directory = ZipDirectory.read(input, password: password);
 
     for (final zfh in directory.fileHeaders) {
       final zf = zfh.file!;
@@ -69,9 +81,7 @@ class ZipDecoder {
       file.compress = compress;
       file.lastModTime = zf.lastModFileDate << 16 | zf.lastModFileTime;
 
-      archive.addFile(file);
+      fnArchiveFile(file);
     }
-
-    return archive;
   }
 }


### PR DESCRIPTION
ZipDecoder contains a 'decodeBuffer' method to deal with (reasonably !!) large files by taking in a stream. 

But to make it more complete , it should have a listener interface to deal with the files one at a time as opposed to uncompressing everything in memory (and running out of it ). 

Of course, it is applicable only if the zip file is large and contains a bunch  of relatively smaller  individual files so they can be processed without bringing all of them into memory at once. 

New type added: 

```dart

/// FnArchiveFile is the callback invoked when the zip decoder iterates through the archive.
typedef FnArchiveFile = void Function(ArchiveFile file);

```

New method `onDecodeBuffer` added to ZipDecoder

```dart
  void onDecodeBuffer(
    InputStreamBase input,
    FnArchiveFile fnArchiveFile, {
    bool verify = false,
    String? password,
  }) ;
```

The above new method is very similar to the original `decodeBuffer` method , except that it takes a function ( `FnArchiveFile` )  as the second argument. 

```dart
  Archive decodeBuffer(
    InputStreamBase input, {
    bool verify = false,
    String? password,
  }) 
```


This should address large files to some extent. 

Let me know your comments regarding the same. 
