### PR TITLE
Fixed InputFileStream taking a memory footprint of 1MB x files count

### DIFF
--- a/test/tests/zip_test.dart
+++ b/test/tests/zip_test.dart
@@ -468,6 +468,42 @@ void main() {
     }
   });
 
+  test('decode many files (100k)', () {
+    final Archive archive = ZipDecoder().decodeBuffer(InputFileStream(
+        p.join(testDirPath, 'res/test_100k_files.zip'),
+        bufferSize: 1024 * 1024,
+      ),
+    );
+
+    final int totalArchiveEntriesCount = archive.files.length;
+    expect(archive.numberOfFiles(), equals(100000));
+
+    int nextEntryIndex = 0;
+    ArchiveFile? file;
+    while (nextEntryIndex < totalArchiveEntriesCount) {
+      file = archive.files[nextEntryIndex];
+      if (!file.isFile) {
+        nextEntryIndex++;
+        continue;
+      }
+      final ArchiveFile f = file;
+      final String filename = f.name;
+      final dynamic data = f.content;
+      f.clear();
+      expect(
+        filename.trim().isEmpty,
+        false,
+        reason: 'Archive file check error: file name empty',
+      );
+      expect(
+        data == null,
+        false,
+        reason: 'Archive file check error: content for $filename is null',
+      );
+      nextEntryIndex++;
+    }
+  });
+
   for (final Z in zipTests) {
     final z = Z as Map<String, dynamic>;
     test('unzip ${z['Name']}', () {


### PR DESCRIPTION
Fixing a bug introduced in version 3.4.3 with https://github.com/brendan-duncan/archive/commit/5699f93e49b4c091646b2348b03d49eb8bc54d88: this change makes `InputFileStream.clone` return a 1MB `Uint8List`, while ZipDirectory.read calls InputFileStream.clone and stores the result for each file in the archive. Because of that, attempting to read an archive containing 100k files would have a 100GB memory footprint.

List of the changes I made:
* Removed an unnecessary max() call in the `InputFileStream` default constructor, and clarified what we're trying to avoid (buffer size > file size) vs. what we're preventing (buffer size < 8).
* Introduced a new `kMinBufferSize` constant to be explicit about the minimum buffer size
* Updated the `InputFileStream.clone` constructor to use `kMinBufferSize` instead of 1MB
* Added some comments inside `InputFileStream.clone` to clarify why that buffer size must be used
* Added a test to ensure we can successfully read an archive with 100k files - before this fix, the test explodes in memory, unless you have more than 100GB of RAM