### PR TITLE
Specific typeFlag

### DIFF
--- a/lib/src/tar_encoder.dart
+++ b/lib/src/tar_encoder.dart
@@ -55,6 +55,8 @@ class TarEncoder {
     if (file.isSymbolicLink) {
       ts.typeFlag = TarFile.TYPE_SYMBOLIC_LINK;
       ts.nameOfLinkedFile = file.nameOfLinkedFile;
+    } else if (!file.isFile) {
+      ts.typeFlag = TarFile.TYPE_DIRECTORY;
     }
     ts.write(_outputStream);
   }


### PR DESCRIPTION
When the file is not a normal file or a symbolic link, typeFlag needs to be specified explicitly.
