### PR TITLE
Pass onProgress to addDirectory in zipDirectory method in ZipFileEncoder

### DIFF
--- a/lib/src/io/zip_file_encoder.dart
+++ b/lib/src/io/zip_file_encoder.dart
@@ -33,6 +33,7 @@ class ZipFileEncoder {
       includeDirName: false,
       level: level,
       followLinks: followLinks,
+      onProgress: onProgress,
     );
     close();
   }


### PR DESCRIPTION
This fixes progress notification in zipDirectory method within ZipFileEncoder. See issue: https://github.com/brendan-duncan/archive/issues/289