### PR TITLE
Make zipDirectory an async function in order to await addDirectory

### DIFF
--- a/example/example.dart
+++ b/example/example.dart
@@ -1,7 +1,7 @@
 import 'dart:io';
 import 'package:archive/archive_io.dart';
 
-void main() {
+Future<void> main() async {
   // Read the Zip file from disk.
   final bytes = File('test.zip').readAsBytesSync();
 
@@ -31,7 +31,7 @@ void main() {
 
   // Zip a directory to out.zip using the zipDirectory convenience method
   var encoder = ZipFileEncoder();
-  encoder.zipDirectory(Directory('out'), filename: 'out.zip');
+  await encoder.zipDirectory(Directory('out'), filename: 'out.zip');
 
   // Manually create a zip of a directory and individual files.
   encoder.create('out2.zip');

--- a/lib/src/io/zip_file_encoder.dart
+++ b/lib/src/io/zip_file_encoder.dart
@@ -18,17 +18,17 @@ class ZipFileEncoder {
 
   ZipFileEncoder({this.password});
 
-  void zipDirectory(Directory dir,
+  Future<void> zipDirectory(Directory dir,
       {String? filename,
       int? level,
       bool followLinks = true,
       void Function(double)? onProgress,
-      DateTime? modified}) {
+      DateTime? modified}) async {
     final dirPath = dir.path;
     final zipPath = filename ?? '$dirPath.zip';
     level ??= GZIP;
     create(zipPath, level: level, modified: modified);
-    addDirectory(
+    await addDirectory(
       dir,
       includeDirName: false,
       level: level,

--- a/test/tests/io_test.dart
+++ b/test/tests/io_test.dart
@@ -453,7 +453,7 @@ void main() {
 
     final encoder = ZipFileEncoder();
     try {
-      encoder.zipDirectory(
+      await encoder.zipDirectory(
           Directory(tmpPath), level: 0, filename: inPath);
       //expect(true, isFalse);
     } catch (e) {

--- a/test/tests/zip_test.dart
+++ b/test/tests/zip_test.dart
@@ -296,7 +296,8 @@ void main() {
       await Process.run('chmod', ['+x', file2.path]);
 
       var dstFilePath = p.join(path, 'test.zip');
-      ZipFileEncoder().zipDirectory(Directory(srcPath), filename: dstFilePath);
+      ZipFileEncoder encoder = ZipFileEncoder();
+      await encoder.zipDirectory(Directory(srcPath), filename: dstFilePath);
 
       // Read
       final bytes = await File(dstFilePath).readAsBytes();


### PR DESCRIPTION
BREAKING CHANGE: zipDirectory must now be called from within an async function and awaited.
See issue: https://github.com/brendan-duncan/archive/issues/292