### PR TITLE
fix: nested zipDirectory filename causes zipping corrupted zip

### DIFF
--- a/lib/src/io/zip_file_encoder.dart
+++ b/lib/src/io/zip_file_encoder.dart
@@ -77,7 +77,7 @@ class ZipFileEncoder {
     close();
   }
 
-  /// Composes the target of the Zip file after a [Directory] is zipped.
+  /// Composes the path (target) of the Zip file after a [Directory] is zipped.
   ///
   /// {@template ZipFileEncoder._composeZipDirectoryPath.filename}
   /// [filename] determines where the Zip file will be created. If [filename]

--- a/lib/src/io/zip_file_encoder.dart
+++ b/lib/src/io/zip_file_encoder.dart
@@ -100,7 +100,8 @@ class ZipFileEncoder {
 
     if (path.isWithin(dirPath, filename)) {
       throw FormatException(
-        'filename ($filename) must not be within the directory being zipped',
+        'filename must not be within the directory being zipped',
+        filename,
       );
     }
 

--- a/lib/src/io/zip_file_encoder.dart
+++ b/lib/src/io/zip_file_encoder.dart
@@ -25,7 +25,7 @@ class ZipFileEncoder {
   /// See also:
   ///
   /// * [zipDirectoryAsync] for the asynchronous version of this method.
-  /// * [_composeZipDirectoryPath] for the logic of composing the zip file path.
+  /// * [_composeZipDirectoryPath] for the logic of composing the Zip file path.
   //@Deprecated('Use zipDirectoryAsync instead')
   void zipDirectory(Directory dir,
       {String? filename,
@@ -56,7 +56,7 @@ class ZipFileEncoder {
   /// See also:
   ///
   /// * [zipDirectory] for the synchronous version of this method.
-  /// * [_composeZipDirectoryPath] for the logic of composing the zip file path.
+  /// * [_composeZipDirectoryPath] for the logic of composing the Zip file path.
   Future<void> zipDirectoryAsync(Directory dir,
       {String? filename,
       int? level,

--- a/lib/src/io/zip_file_encoder.dart
+++ b/lib/src/io/zip_file_encoder.dart
@@ -18,6 +18,14 @@ class ZipFileEncoder {
 
   ZipFileEncoder({this.password});
 
+  /// Zips a [dir] to a Zip file synchronously.
+  ///
+  /// {@macro ZipFileEncoder._composeZipDirectoryPath.filename}
+  ///
+  /// See also:
+  ///
+  /// * [zipDirectoryAsync] for the asynchronous version of this method.
+  /// * [_composeZipDirectoryPath] for the logic of composing the zip file path.
   //@Deprecated('Use zipDirectoryAsync instead')
   void zipDirectory(Directory dir,
       {String? filename,
@@ -25,10 +33,12 @@ class ZipFileEncoder {
       bool followLinks = true,
       void Function(double)? onProgress,
       DateTime? modified}) {
-    final dirPath = dir.path;
-    final zipPath = filename ?? '$dirPath.zip';
-    level ??= GZIP;
-    create(zipPath, level: level, modified: modified);
+    create(
+      _composeZipDirectoryPath(dir: dir, filename: filename),
+      level: level ??= GZIP,
+      modified: modified,
+    );
+
     _addDirectory(
       dir,
       includeDirName: false,
@@ -39,22 +49,62 @@ class ZipFileEncoder {
     close();
   }
 
+  /// Zips a [dir] to a Zip file asynchronously.
+  ///
+  /// {@macro ZipFileEncoder._composeZipDirectoryPath.filename}
+  ///
+  /// See also:
+  ///
+  /// * [zipDirectory] for the synchronous version of this method.
+  /// * [_composeZipDirectoryPath] for the logic of composing the zip file path.
   Future<void> zipDirectoryAsync(Directory dir,
       {String? filename,
       int? level,
       bool followLinks = true,
       void Function(double)? onProgress,
       DateTime? modified}) async {
-    final dirPath = dir.path;
-    final zipPath = filename ?? '$dirPath.zip';
-    level ??= GZIP;
-    create(zipPath, level: level, modified: modified);
+    create(
+      _composeZipDirectoryPath(dir: dir, filename: filename),
+      level: level ??= GZIP,
+      modified: modified,
+    );
+
     await addDirectory(dir,
         includeDirName: false,
         level: level,
         followLinks: followLinks,
         onProgress: onProgress);
     close();
+  }
+
+  /// Composes the target of the Zip file after a [Directory] is zipped.
+  ///
+  /// {@template ZipFileEncoder._composeZipDirectoryPath.filename}
+  /// [filename] determines where the Zip file will be created. If [filename]
+  /// is not specified, the name of the directory will be used with a '.zip'
+  /// extension. If [filename] is within [dir], it will throw a [FormatException].
+  /// {@endtemplate}
+  ///
+  /// See also:
+  ///
+  /// * [zipDirectory] and [zipDirectoryAsync] for the methods that use this logic.
+  String _composeZipDirectoryPath({
+    required Directory dir,
+    required String? filename,
+  }) {
+    final dirPath = dir.path;
+
+    if (filename == null) {
+      return '$dirPath.zip';
+    }
+
+    if (path.isWithin(dirPath, filename)) {
+      throw FormatException(
+        'filename ($filename) must not be within the directory being zipped',
+      );
+    }
+
+    return filename;
   }
 
   void open(String zipPath) => create(zipPath);

--- a/test/tests/io_test.dart
+++ b/test/tests/io_test.dart
@@ -472,4 +472,64 @@ void main() {
     expect(dstFiles.length, equals(srcFiles.length));
     //encoder.close();
   });
+
+  group('$ZipFileEncoder', () {
+    test(
+      'zipDirectory throws a FormatException when filename is within dir',
+      () {
+        final encoder = ZipFileEncoder();
+        final invalidFilename = p.join(testDirPath, 'res/test2.zip');
+
+        expect(
+          () => encoder.zipDirectory(
+            Directory(testDirPath),
+            filename: invalidFilename,
+          ),
+          throwsA(
+            isA<FormatException>()
+                .having(
+                  (exception) => exception.message,
+                  'message',
+                  equals(
+                      'filename must not be within the directory being zipped'),
+                )
+                .having(
+                  (exception) => exception.source,
+                  'source',
+                  equals(invalidFilename),
+                ),
+          ),
+        );
+      },
+    );
+
+    test(
+      'zipDirectoryAsync throws a FormatException when filename is within dir',
+      () async {
+        final encoder = ZipFileEncoder();
+        final invalidFilename = p.join(testDirPath, 'res/test2.zip');
+
+        await expectLater(
+          () => encoder.zipDirectoryAsync(
+            Directory(testDirPath),
+            filename: invalidFilename,
+          ),
+          throwsA(
+            isA<FormatException>()
+                .having(
+                  (exception) => exception.message,
+                  'message',
+                  equals(
+                      'filename must not be within the directory being zipped'),
+                )
+                .having(
+                  (exception) => exception.source,
+                  'source',
+                  equals(invalidFilename),
+                ),
+          ),
+        );
+      },
+    );
+  });
 }


### PR DESCRIPTION
Resolves #297 

This change can be considered as a breaking change for those users that were using the `.zipDirectory` or `.zipDirectoryAsync` incorrectly.
