### PR TITLE
feat: `InputStream` to `InputStreamBase` for zlib

### DIFF
--- a/lib/src/zlib/_zlib_decoder_io.dart
+++ b/lib/src/zlib/_zlib_decoder_io.dart
@@ -14,7 +14,7 @@ class _ZLibDecoder extends ZLibDecoderBase {
   }
 
   @override
-  List<int> decodeBuffer(InputStream input, {bool verify = false}) {
+  List<int> decodeBuffer(InputStreamBase input, {bool verify = false}) {
     return decodeBytes(input.toUint8List(), verify: verify);
   }
 }

--- a/lib/src/zlib/_zlib_decoder_js.dart
+++ b/lib/src/zlib/_zlib_decoder_js.dart
@@ -20,7 +20,7 @@ class _ZLibDecoder extends ZLibDecoderBase {
   }
 
   @override
-  List<int> decodeBuffer(InputStream input, {bool verify = false}) {
+  List<int> decodeBuffer(InputStreamBase input, {bool verify = false}) {
     /*
      * The zlib format has the following structure:
      * CMF  1 byte

--- a/lib/src/zlib/zlib_decoder_base.dart
+++ b/lib/src/zlib/zlib_decoder_base.dart
@@ -6,5 +6,5 @@ abstract class ZLibDecoderBase {
 
   List<int> decodeBytes(List<int> data, {bool verify = false});
 
-  List<int> decodeBuffer(InputStream input, {bool verify = false});
+  List<int> decodeBuffer(InputStreamBase input, {bool verify = false});
 }

--- a/lib/src/zlib_decoder.dart
+++ b/lib/src/zlib_decoder.dart
@@ -13,7 +13,7 @@ class ZLibDecoder {
     return platformZLibDecoder.decodeBytes(data, verify: verify);
   }
 
-  List<int> decodeBuffer(InputStream input, {bool verify = false}) {
+  List<int> decodeBuffer(InputStreamBase input, {bool verify = false}) {
     return platformZLibDecoder.decodeBuffer(input, verify: verify);
   }
 }


### PR DESCRIPTION
When I was using it, I found that the method signature of zlib's decoder was inconsistent with other decoders.
So, I modify to the same signature type.

---

By the way,  if the encoders and decoders have a common mixin/abstract class this problem might not happen.