### PR TITLE
Prevent modifying Archive.files directly - doing this makes "files" a…

### DIFF
--- a/lib/src/archive.dart
+++ b/lib/src/archive.dart
@@ -4,11 +4,14 @@ import 'dart:collection';
 /// A collection of files
 class Archive extends IterableBase<ArchiveFile> {
   /// The list of files in the archive.
-  List<ArchiveFile> files = [];
+  final List<ArchiveFile> _files = [];
   final Map<String, int> _fileMap = {};
 
   /// A global comment for the archive.
   String? comment;
+
+  /// Unmodifiable view of the files in the archive.
+  List<ArchiveFile> get files => UnmodifiableListView(_files);
 
   /// Add a file to the archive.
   void addFile(ArchiveFile file) {
@@ -16,21 +19,21 @@ class Archive extends IterableBase<ArchiveFile> {
     // will replace the previous file.
     var index = _fileMap[file.name];
     if (index != null) {
-      files[index] = file;
+      _files[index] = file;
       return;
     }
     // No existing file was in the archive with the same path, add it to the
     // archive.
-    files.add(file);
-    _fileMap[file.name] = files.length - 1;
+    _files.add(file);
+    _fileMap[file.name] = _files.length - 1;
   }
 
   Future<void> clear() async {
     var futures = <Future<void>>[];
-    for (var fp in files) {
+    for (var fp in _files) {
       futures.add(fp.close());
     }
-    files.clear();
+    _files.clear();
     _fileMap.clear();
     comment = null;
     await Future.wait(futures);
@@ -38,51 +41,51 @@ class Archive extends IterableBase<ArchiveFile> {
 
   /// The number of files in the archive.
   @override
-  int get length => files.length;
+  int get length => _files.length;
 
   /// Get a file from the archive.
-  ArchiveFile operator [](int index) => files[index];
+  ArchiveFile operator [](int index) => _files[index];
 
   /// Find a file with the given [name] in the archive. If the file isn't found,
   /// null will be returned.
   ArchiveFile? findFile(String name) {
     var index = _fileMap[name];
-    return index != null ? files[index] : null;
+    return index != null ? _files[index] : null;
   }
 
   /// The number of files in the archive.
   int numberOfFiles() {
-    return files.length;
+    return _files.length;
   }
 
   /// The name of the file at the given [index].
   String fileName(int index) {
-    return files[index].name;
+    return _files[index].name;
   }
 
   /// The decompressed size of the file at the given [index].
   int fileSize(int index) {
-    return files[index].size;
+    return _files[index].size;
   }
 
   /// The decompressed data of the file at the given [index].
   List<int> fileData(int index) {
-    return files[index].content as List<int>;
+    return _files[index].content as List<int>;
   }
 
   @override
-  ArchiveFile get first => files.first;
+  ArchiveFile get first => _files.first;
 
   @override
-  ArchiveFile get last => files.last;
+  ArchiveFile get last => _files.last;
 
   @override
-  bool get isEmpty => files.isEmpty;
+  bool get isEmpty => _files.isEmpty;
 
   // Returns true if there is at least one element in this collection.
   @override
-  bool get isNotEmpty => files.isNotEmpty;
+  bool get isNotEmpty => _files.isNotEmpty;
 
   @override
-  Iterator<ArchiveFile> get iterator => files.iterator;
+  Iterator<ArchiveFile> get iterator => _files.iterator;
 }


### PR DESCRIPTION
…nd "_fileMap" go out of sync

### Problem

When you modify `Archive.files` directly, it does out of sync with `_fileMap`, and it results in errors or files disappearing mysteriously.

Example:
```dart
Future<void> main() async {
  final archive = Archive();
  archive.addFile(ArchiveFile('a.txt', 1, Uint8List.fromList([0])));
  archive.files.clear();
  archive.addFile(ArchiveFile('a.txt', 1, Uint8List.fromList([0])));
}
```

Output:
```
Unhandled exception:
RangeError (index): Invalid value: Valid value range is empty: 0
#0      List._setIndexed (dart:core-patch/growable_array.dart:273:49)
#1      List.[]= (dart:core-patch/growable_array.dart:268:5)
#2      Archive.addFile (package:archive/src/archive.dart:23:13)
#3      main (file:///Users/anton/dev/archive/example/example.dart:9:11)
#4      _delayEntrypointInvocation.<anonymous closure> (dart:isolate-patch/isolate_patch.dart:296:19)
#5      _RawReceivePort._handleMessage (dart:isolate-patch/isolate_patch.dart:189:12)
```

It's even worse when it doesn't fail, but returns unexpected results:
```dart
Future<void> main() async {
  final archive = Archive();
  archive.addFile(ArchiveFile('a.txt', 1, Uint8List.fromList([0])));
  archive.files.clear();
  archive.addFile(ArchiveFile('b.txt', 1, Uint8List.fromList([0])));
  archive.addFile(ArchiveFile('a.txt', 1, Uint8List.fromList([0])));
  // Should be 2, but it prints 1
  print('Number of files in archive: ${archive.length}');
}
```

### Solution

Since we can't keep `files` and `_fileMap` in sync when `files` is modified directly, `Archive.files` should return an unmodifiable view of the list of files. This way, attempts to modify `Archive.files` will fail right away with a clear message and force the user of the library to use methods like `Archive.addFile()` or `Archive.clear()`.