### PR TITLE
#312 zipDirectory with password bug fix

### DIFF
--- a/lib/src/zip_encoder.dart
+++ b/lib/src/zip_encoder.dart
@@ -354,8 +354,8 @@ class ZipEncoder {
     output.writeBytes(encodedFilename);
     output.writeBytes(extra);
 
-    if (password != null) {
-      output.writeBytes(salt!);
+    if (password != null && salt != null) {
+      output.writeBytes(salt);
       output.writeBytes(_pwdVer!);
     }
 


### PR DESCRIPTION
zipDirectory - when ZipFileEncoder is initialized with a password and there are subdirectories in the input directory => Null check operator used on a null value