### PR TITLE
#312 zipDirectory - ZipFileEncoder is initialized with a password

### DIFF
--- a/lib/src/zip_encoder.dart
+++ b/lib/src/zip_encoder.dart
@@ -364,7 +364,7 @@ class ZipEncoder {
       output.writeInputStream(compressedData);
     }
 
-    if (password != null) {
+    if (password != null && _mac != null) {
       output.writeBytes(_mac!);
     }
   }


### PR DESCRIPTION
I've encountered another null check operator on a null value with the same scenario, this time the _mac parameter was null, I changed the corresponding line, and tested the zip file and ensured it has no problem.
Thanks