### PR TITLE
fix: Add autoClose check on ZipEncoder.addFile()

### DIFF
--- a/lib/src/zip_encoder.dart
+++ b/lib/src/zip_encoder.dart
@@ -263,7 +263,9 @@ class ZipEncoder {
 
     fileData.compressedData = null;
 
-    file.closeSync();
+    if (autoClose) {
+      file.closeSync();
+    }
   }
 
   void endEncode({String? comment = ''}) {


### PR DESCRIPTION
When calling `ZipEnconder.addFile()` method, the `autoClose` parameter is being ignored. This PR adds a check to automatically close the stream only when `autoClose` is set to true.