### PR TITLE
Async / Futures handling fixes

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -19,3 +19,5 @@ linter:
   rules:
     - avoid_print
     - camel_case_types
+    - unawaited_futures
+    - discarded_futures

--- a/example/example.dart
+++ b/example/example.dart
@@ -37,5 +37,5 @@ Future<void> main() async {
   encoder.create('out2.zip');
   encoder.addDirectory(Directory('out'));
   encoder.addFile(File('test.zip'));
-  encoder.close();
+  encoder.closeSync();
 }

--- a/example/large_zip_in_browser.dart
+++ b/example/large_zip_in_browser.dart
@@ -110,7 +110,7 @@ RamFileData _writeFilesDataAsZipRamData(List<_FileData> fileDataList) {
   }
 
   // Close the ZipFileEncoder
-  zipEncoder.close();
+  zipEncoder.closeSync();
 
   return outputRamFileData;
 }

--- a/lib/src/io/zip_file_encoder.dart
+++ b/lib/src/io/zip_file_encoder.dart
@@ -45,7 +45,7 @@ class ZipFileEncoder {
       followLinks: followLinks,
       onProgress: onProgress,
     );
-    close();
+    closeSync();
   }
 
   /// Zips a [dir] to a Zip file asynchronously.
@@ -73,7 +73,7 @@ class ZipFileEncoder {
         level: level,
         followLinks: followLinks,
         onProgress: onProgress);
-    close();
+    closeSync();
   }
 
   /// Composes the path (target) of the Zip file after a [Directory] is zipped.
@@ -224,8 +224,13 @@ class ZipFileEncoder {
     _encoder.addFile(file);
   }
 
-  void close() {
+  void closeSync() {
     _encoder.endEncode();
-    _output.close();
+    _output.closeSync();
+  }
+
+  Future<void> close() async {
+    _encoder.endEncode();
+    await _output.close();
   }
 }

--- a/test/tests/io_test.dart
+++ b/test/tests/io_test.dart
@@ -334,7 +334,7 @@ void main() {
       final content = fileEntry.value;
       zipEncoder.addArchiveFile(ArchiveFile(name, content.length, content));
     }
-    zipEncoder.close();
+    zipEncoder.closeSync();
     final Uint8List zippedBytes = Uint8List(ramFileData.length);
     ramFileData.readIntoSync(zippedBytes, 0, zippedBytes.length);
     final RamFileData readRamFileData = RamFileData.fromBytes(zippedBytes);
@@ -358,7 +358,7 @@ void main() {
     final encoder = ZipFileEncoder();
     encoder.create('$testDirPath/out/testEmpty.zip');
     encoder.addFile(File('$testDirPath/res/emptyfile.txt'));
-    encoder.close();
+    encoder.closeSync();
 
     final zipDecoder = ZipDecoder();
     final f = File('$testDirPath/out/testEmpty.zip');
@@ -467,7 +467,7 @@ void main() {
     encoder.addDirectory(Directory('$testDirPath/res/test2'));
     encoder.addFile(File('$testDirPath/res/cat.jpg'));
     encoder.addFile(File('$testDirPath/res/tarurls.txt'));
-    encoder.close();
+    encoder.closeSync();
 
     final zipDecoder = ZipDecoder();
     final f = File('$testDirPath/out/example2.zip');


### PR DESCRIPTION
After finding a fix for a bug in my app requiring the implementation of `ZipFileEncoder.close()` to be adjusted, I also found a lot of places in the code where async code handling could be improved.

I started by adjusting the implementation of `ZipFileEncoder.close()` and adding those linter rules:

```
    - unawaited_futures
    - discarded_futures
```

It looks like a lot of places in the code could be improved with await / Future return declarations, but it could have implications I don't necessarily understand.

Should I look at doing more refactoring with the help of those linter rules, or should I remove those linter rules and keep the changes to the limited scope of `ZipFileEncoder.close()`?