### PR TITLE
Rev `package:pointycastle` version to include bugfix

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: archive
-version: 3.4.10
+version: 3.4.11
 description: >-
   Provides encoders and decoders for various archive and compression formats
   such as zip, tar, bzip2, gzip, and zlib.
@@ -10,7 +10,7 @@ environment:
 dependencies:
   crypto: ^3.0.3
   path: ^1.8.0
-  pointycastle: ^3.7.3
+  pointycastle: ^3.9.0
 
 dev_dependencies:
   http: ^1.1.0


### PR DESCRIPTION
The pointycastle package recently [fixed a bug](https://github.com/bcgit/pc-dart/pull/231) in the `3.8.0` release. This PR updates the pointycastle version past that bug, to avoid [breakages](https://github.com/mosuem/pc-dart/actions/runs/8686453387/job/23817981444) of `package:grpc`.