### PR TITLE
Add `topics` to `pubspec.yaml`

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,6 +4,12 @@ description: >-
   Provides encoders and decoders for various archive and compression formats
   such as zip, tar, bzip2, gzip, and zlib.
 repository: https://github.com/brendan-duncan/archive
+topics:
+ - archive
+ - zip
+ - tar
+ - gzip
+ - xz
 
 environment:
   sdk: ^3.0.0


### PR DESCRIPTION
Topics helps users on pub.dev discover packages, and related packages.

You can see a list of [topics here](https://pub.dev/topics).
You can also make your own topics.

Topics are added to `pubspec.yaml` as follows:

```yaml
topics:
 - my-topic
 - some-other-topic
```

See also: https://dart.dev/tools/pub/pubspec#topics