### PR TITLE
improve _findSignature - reduce duplicate checks

### DIFF
--- a/lib/src/codecs/zip/zip_directory.dart
+++ b/lib/src/codecs/zip/zip_directory.dart
@@ -151,10 +151,12 @@ class ZipDirectory {
     final length = input.length - 4;
     const bufferSize = 1024;
     final chunkSize = length < bufferSize ? length : bufferSize;
+
     var sp = length - chunkSize;
-    final ep = sp + chunkSize;
+    int ep() => sp + chunkSize;
+
     while (sp >= 0) {
-      for (var ip = sp; ip < ep; ip++) {
+      for (var ip = sp; ip < ep(); ip++) {
         input.setPosition(ip);
         final sig = input.readUint32();
         if (sig == eocdSignature) {
@@ -168,6 +170,7 @@ class ZipDirectory {
         sp -= chunkSize;
       }
     }
+
     return -1;
   }
 }

--- a/lib/src/codecs/zip/zip_directory.dart
+++ b/lib/src/codecs/zip/zip_directory.dart
@@ -152,22 +152,22 @@ class ZipDirectory {
     const bufferSize = 1024;
     final chunkSize = length < bufferSize ? length : bufferSize;
 
-    var sp = length - chunkSize;
-    int ep() => sp + chunkSize;
+    var startPos = length - chunkSize;
+    int endPos() => startPos + chunkSize;
 
-    while (sp >= 0) {
-      for (var ip = sp; ip < ep(); ip++) {
-        input.setPosition(ip);
+    while (startPos >= 0) {
+      for (var innerPos = startPos; innerPos < endPos(); innerPos++) {
+        input.setPosition(innerPos);
         final sig = input.readUint32();
         if (sig == eocdSignature) {
           input.setPosition(pos);
-          return ip;
+          return innerPos;
         }
       }
-      if (sp > 0 && sp < chunkSize) {
-        sp = 0;
+      if (startPos > 0 && startPos < chunkSize) {
+        startPos = 0;
       } else {
-        sp -= chunkSize;
+        startPos -= chunkSize;
       }
     }
 


### PR DESCRIPTION
28a4bb9a: fix(ZipDirectory): move endPosition relative to startPosition

Previously, the rear part of the InputStream was read and checked over and over again because the endPosition did not change. This fix always applies the chunkSize to the startPosition and thus moves the window evenly across the file.