### PR TITLE
ZipDecoder.decodeBytes infinite loop fixed

### DIFF
--- a/lib/src/codecs/zip/zip_directory.dart
+++ b/lib/src/codecs/zip/zip_directory.dart
@@ -155,7 +155,7 @@ class ZipDirectory {
     var startPos = length - chunkSize;
     int endPos() => startPos + chunkSize;
 
-    while (startPos >= 0) {
+    while (startPos >= 0 && startPos < length) {
       for (var innerPos = startPos; innerPos < endPos(); innerPos++) {
         input.setPosition(innerPos);
         final sig = input.readUint32();

--- a/test/zip_test.dart
+++ b/test/zip_test.dart
@@ -218,6 +218,11 @@ void main() async {
       expect(decoded.length, equals(0));
     });
 
+    test('decode 0 bytes', () async {
+      final archive = ZipDecoder().decodeBytes(Uint8List(0));
+      expect(archive.length, equals(0));
+    });
+
     test('apk', () async {
       final archive = Archive()
         ..addFile(


### PR DESCRIPTION
I recently starting using the GitHub repo at head to try 4.0.0: its working great on every platform, thank you.

I have a test that, eliding intermediate details, ends up calling ZipDecoder().decodeBytes(Uint8List(0)). It started hanging on CI, and diving into it, it turned out it was hanging in this loop.

This patches fixes the hang and adds a test. I'm somewhat naive about the loop, I am not 100% certain this is the right inflection point for the fix.