### PR TITLE
Fix js import

### DIFF
--- a/lib/src/codecs/zlib/_gzip_decoder.dart
+++ b/lib/src/codecs/zlib/_gzip_decoder.dart
@@ -1,3 +1,3 @@
 export '_gzip_decoder_stub.dart'
     if (dart.library.io) '_gzip_decoder_io.dart'
-    if (dart.library.js) '_gzip_decoder_web.dart';
+    if (dart.library.js_interop) '_gzip_decoder_web.dart';

--- a/lib/src/codecs/zlib/_gzip_encoder.dart
+++ b/lib/src/codecs/zlib/_gzip_encoder.dart
@@ -1,3 +1,3 @@
 export '_gzip_encoder_stub.dart'
     if (dart.library.io) '_gzip_encoder_io.dart'
-    if (dart.library.js) '_gzip_encoder_web.dart';
+    if (dart.library.js_interop) '_gzip_encoder_web.dart';

--- a/lib/src/codecs/zlib/_zlib_decoder.dart
+++ b/lib/src/codecs/zlib/_zlib_decoder.dart
@@ -1,3 +1,3 @@
 export '_zlib_decoder_stub.dart'
     if (dart.library.io) '_zlib_decoder_io.dart'
-    if (dart.library.js) '_zlib_decoder_web.dart';
+    if (dart.library.js_interop) '_zlib_decoder_web.dart';

--- a/lib/src/codecs/zlib/_zlib_encoder.dart
+++ b/lib/src/codecs/zlib/_zlib_encoder.dart
@@ -1,3 +1,3 @@
 export '_zlib_encoder_stub.dart'
     if (dart.library.io) '_zlib_encoder_io.dart'
-    if (dart.library.js) '_zlib_encoder_web.dart';
+    if (dart.library.js_interop) '_zlib_encoder_web.dart';

--- a/lib/src/codecs/zlib/inflate_buffer.dart
+++ b/lib/src/codecs/zlib/inflate_buffer.dart
@@ -3,6 +3,6 @@ import 'dart:typed_data';
 
 import '_inflate_buffer_stub.dart'
     if (dart.library.io) '_inflate_buffer_io.dart'
-    if (dart.library.js) '_inflate_buffer_web.dart';
+    if (dart.library.js_interop) '_inflate_buffer_web.dart';
 
 FutureOr<Uint8List>? inflateBuffer(List<int> data) => inflateBuffer_(data);

--- a/lib/src/util/crc64.dart
+++ b/lib/src/util/crc64.dart
@@ -1,6 +1,6 @@
 import '_crc64_stub.dart'
     if (dart.library.io) '_crc64_io.dart'
-    if (dart.library.js) '_crc64_html.dart';
+    if (dart.library.js_interop) '_crc64_html.dart';
 
 int getCrc64(List<int> array, [int crc = 0]) => getCrc64_(array, crc);
 

--- a/lib/src/util/file_handle.dart
+++ b/lib/src/util/file_handle.dart
@@ -1,3 +1,3 @@
 export '_file_handle.dart'
     if (dart.library.io) '_file_handle_io.dart'
-    if (dart.library.js) '_file_handle_html.dart';
+    if (dart.library.js_interop) '_file_handle_html.dart';


### PR DESCRIPTION
When using "flutter build web --wasm" you will get this error:
Unsupported operation: Cannot create a zlib encoder without dart:html or dart:io.

See https://github.com/dart-lang/sdk/blob/f1394aa2db4938b9b8a4074725942e6efb16d298/CHANGELOG.md?plain=1#L293 for the changelog inside dart.
When using web, we should use `dart.library.js_interop`, see https://dart.dev/interop/js-interop/package-web