### PR TITLE
Fix ZipFileEncoder's addFile level parameter

### DIFF
--- a/lib/src/codecs/zip_encoder.dart
+++ b/lib/src/codecs/zip_encoder.dart
@@ -181,7 +181,7 @@ class ZipEncoder {
   }
 
   void add(ArchiveFile entry,
-      {bool autoClose = true, ArchiveCallback? callback}) {
+      {bool autoClose = true, ArchiveCallback? callback, int? level}) {
     final fileData = _ZipFileData();
     _data.files.add(fileData);
 
@@ -244,7 +244,7 @@ class ZipEncoder {
         final output = OutputMemoryStream();
         platformZLibEncoder.encodeStream(
             content!.getStream(decompress: false), output,
-            level: _data.level ?? 6, raw: true);
+            level: level ?? _data.level ?? 6, raw: true);
         compressedData = InputMemoryStream(output.getBytes());
       }
     }

--- a/lib/src/io/zip_file_encoder.dart
+++ b/lib/src/io/zip_file_encoder.dart
@@ -133,7 +133,7 @@ class ZipFileEncoder {
     }
   }
 
-  void addFileSync(File file, [String? filename, int? level = gzip]) {
+  void addFileSync(File file, [String? filename, int? level]) {
     final fileStream = InputFileStream(file.path);
     final archiveFile =
         ArchiveFile.stream(filename ?? path.basename(file.path), fileStream);
@@ -147,10 +147,10 @@ class ZipFileEncoder {
 
     archiveFile.mode = (file.statSync()).mode;
 
-    _encoder.add(archiveFile);
+    _encoder.add(archiveFile, level: level);
   }
 
-  Future<void> addFile(File file, [String? filename, int? level = gzip]) async {
+  Future<void> addFile(File file, [String? filename, int? level]) async {
     final fileStream = InputFileStream(file.path);
     final archiveFile =
         ArchiveFile.stream(filename ?? path.basename(file.path), fileStream);
@@ -164,7 +164,7 @@ class ZipFileEncoder {
 
     archiveFile.mode = (await file.stat()).mode;
 
-    _encoder.add(archiveFile);
+    _encoder.add(archiveFile, level: level);
 
     await fileStream.close();
   }

--- a/test/io_test.dart
+++ b/test/io_test.dart
@@ -500,6 +500,26 @@ void main() {
     expect(archive.length, equals(6));
   });
 
+  test('stream zip encode levels', () async {
+    final encoder = ZipFileEncoder();
+    encoder.create('$testOutputPath/example3.zip');
+    await encoder.addFile(File('test/_data/tarurls.txt'), "tarurls_0.txt", 0);
+    await encoder.addFile(File('test/_data/tarurls.txt'), "tarurls_1.txt", 1);
+    await encoder.addFile(File('test/_data/tarurls.txt'), "tarurls_6.txt", 6);
+    encoder.closeSync();
+
+    final zipDecoder = ZipDecoder();
+    final f = File('$testOutputPath/example3.zip');
+    final archive = zipDecoder.decodeBytes(f.readAsBytesSync(), verify: true);
+
+    // Ensure that higher compression levels produce smaller files
+    final f0 = archive.files.firstWhere((o) => o.name == "tarurls_0.txt");
+    final f1 = archive.files.firstWhere((o) => o.name == "tarurls_1.txt");
+    final f6 = archive.files.firstWhere((o) => o.name == "tarurls_6.txt");
+    assert(f1.rawContent!.length < f0.rawContent!.length);
+    assert(f6.rawContent!.length < f1.rawContent!.length);
+  });
+
   test('decode_empty_directory', () {
     final zip = ZipDecoder();
     final archive =


### PR DESCRIPTION
The `level` option on `ZipFileEncoder.addFile` doesn't currently do anything. My understanding is it should allow individual files to have different compression levels compared to the whole archive.

With this PR:
- If it is present, that compression level will be used
- If it is not present, the archive's default compression level will be used

Incidentally, there is a `compression` field on `ArchiveFile` class, but this isn't actually used anywhere ever. Should this be removed to avoid confusion?