### PR TITLE
Fix _files and _fileMap going out of sync after calling removeFile()

### DIFF
--- a/lib/src/archive/archive.dart
+++ b/lib/src/archive/archive.dart
@@ -42,6 +42,8 @@ class Archive extends IterableBase<ArchiveFile> {
     if (index != null) {
       _files.removeAt(index);
       _fileMap.remove(file.name);
+      // Indexes have changed, update the file map.
+      _updateFileMap();
     }
   }
 
@@ -51,6 +53,8 @@ class Archive extends IterableBase<ArchiveFile> {
     }
     _fileMap.remove(_files[index].name);
     _files.removeAt(index);
+    // Indexes have changed, update the file map.
+    _updateFileMap();
   }
 
   Future<void> clear() async {
@@ -124,4 +128,11 @@ class Archive extends IterableBase<ArchiveFile> {
 
   @override
   Iterator<ArchiveFile> get iterator => _files.iterator;
+
+  void _updateFileMap() {
+    _fileMap.clear();
+    for (var i = 0; i < _files.length; i++) {
+      _fileMap[_files[i].name] = i;
+    }
+  }
 }

--- a/test/archive_test.dart
+++ b/test/archive_test.dart
@@ -36,5 +36,32 @@ void main() {
       archive.clearSync();
       expect(archive.length, 0);
     });
+
+    test('remove file', () {
+      final archive = Archive();
+      final file1 = ArchiveFile.bytes("a", Uint8List.fromList([0]));
+      final file2 = ArchiveFile.bytes("b", Uint8List.fromList([1]));
+      archive.addFile(file1);
+      archive.addFile(file2);
+      expect(archive.length, 2);
+      archive.removeFile(file1);
+      expect(archive.length, 1);
+      expect(archive[0].name, "b");
+      expect(archive[0].getContent()!.readByte(), 1);
+      archive.removeFile(file2);
+      expect(archive.length, 0);
+    });
+
+    test('remove file at index', () {
+      final archive = Archive();
+      archive.addFile(ArchiveFile.bytes("a", Uint8List.fromList([0])));
+      archive.addFile(ArchiveFile.bytes("b", Uint8List.fromList([1])));
+      archive.removeAt(0);
+      expect(archive.length, 1);
+      expect(archive[0].name, "b");
+      expect(archive[0].getContent()!.readByte(), 1);
+      archive.removeAt(0);
+      expect(archive.length, 0);
+    });
   });
 }


### PR DESCRIPTION
When you call `removeFile()`, `_files` and `_fileMap` can go out of sync because removing a file changes indexes of other files. This is reproduced in the `remove file` test.