### PR TITLE
Bump posix to 6.0.2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ environment:
 dependencies:
   crypto: ^3.0.3
   path: ^1.8.0
-  posix: ^6.0.1
+  posix: ^6.0.2
 
 dev_dependencies:
   build_runner: ^2.4.14


### PR DESCRIPTION
Roll in https://github.com/onepub-dev/dart_posix/issues/16, so we can roll a new `package:archive` into Flutter, and then reland https://github.com/dart-lang/sdk/commit/7427e655f6f502f925d56569e100dbc2347fd43e.