### PR TITLE
fix: prevent RangeError when parsing ZIP extra fields with trailing bytes

### DIFF
--- a/lib/src/codecs/zip/zip_file_header.dart
+++ b/lib/src/codecs/zip/zip_file_header.dart
@@ -55,7 +55,7 @@ class ZipFileHeader {
       // we ignore it for better compatibility.
       if (extraLen >= 4) {
         final extra = InputMemoryStream(extraField!);
-        while (!extra.isEOS) {
+        while (extra.length >= 4) {
           final id = extra.readUint16();
           var size = extra.readUint16();
           final extraBytes = extra.readBytes(size);


### PR DESCRIPTION
Some ZIP/APK files (especially repackaged or re-signed APKs) contain extra fields with 1-3 trailing padding bytes that do not form a valid sub-field header. The previous loop condition `!extra.isEOS` would attempt to read a 4-byte sub-field header (id + size) from these remaining bytes, causing a RangeError.

Changed the loop condition to require at least 4 bytes remaining before attempting to read the next sub-field header. This is consistent with the ZIP specification (APPNOTE 4.5.1), which defines each extra field sub-field as a minimum of 4 bytes (2-byte Header ID + 2-byte Data Size).