### PR TITLE
Exclude generated output from published package

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -1,3 +1,4 @@
 test/
+_out/
 web/
 example/


### PR DESCRIPTION
## Summary

- Exclude generated `_out/` artifacts from published packages.
- Align Archive's publish exclusions with `brendan-duncan/image`.

## Why

When a `.pubignore` file exists, Dart uses it instead of `.gitignore` for `dart pub publish`. Archive already ignores `_out/` in Git, but not when publishing, so generated test artifacts can be included in releases.

The official `archive` 4.0.8 and 4.0.9 package archives contain 4,048 `_out/` entries (about 17 MiB uncompressed), including 4,011 `.bin` files. The compressed package grew from about 116 KiB in 4.0.7 to about 562 KiB in 4.0.8 and 4.0.9.

This also creates noisy downstream scans. For example, the Ente Photos F-Droid build removed 4,011 binary files from `archive/_out`, and zero from the `image` package. This change mirrors brendan-duncan/image@275a59896c71e21a5240267ac57939c2770438d2, which already excludes `_out/` in `.pubignore`.

## Validation

- Ran `dart pub publish --dry-run --verbose` with a temporary `_out/pubignore-fixture.txt`.
- Confirmed the fixture was absent from the publish output.
- Package validation completed with zero warnings, and `dart analyze` reported no issues.
