### PR TITLE
Increased decode speed for XZDecoder, fixed reset dictionary in control == 1, optimized ram usage for dictionary for large files

### DIFF
--- a/lib/src/codecs/lzma/lzma_decoder.dart
+++ b/lib/src/codecs/lzma/lzma_decoder.dart
@@ -83,6 +83,13 @@ class LzmaDecoder {
     reset();
   }
 
+  void trimDictionary(int maxSize) {
+    if (_writePosition <= maxSize) return;
+    final start = _writePosition - maxSize;
+    _dictionary = _dictionary.sublist(start, _writePosition);
+    _writePosition = maxSize;
+  }
+
   // Reset the decoder.
   void reset(
       {int? positionBits,

--- a/lib/src/codecs/lzma/lzma_decoder.dart
+++ b/lib/src/codecs/lzma/lzma_decoder.dart
@@ -138,11 +138,17 @@ class LzmaDecoder {
   Uint8List decodeUncompressed(InputStream input, int uncompressedLength) {
     final inputData = input.readBytes(uncompressedLength);
 
-    var initialSize = _dictionary.length;
-    var finalSize = initialSize + uncompressedLength;
-    final newDictionary = Uint8List(finalSize);
-    newDictionary.setAll(0, _dictionary);
-    _dictionary = newDictionary;
+    final initialSize = _writePosition;
+    final finalSize = initialSize + uncompressedLength;
+    if (finalSize > _dictionary.length) {
+      var newLen = _dictionary.isEmpty ? finalSize : _dictionary.length;
+      while (newLen < finalSize) newLen *= 2;
+      final newDictionary = Uint8List(newLen);
+      if (_writePosition > 0) {
+        newDictionary.setRange(0, _writePosition, _dictionary);
+      }
+      _dictionary = newDictionary;
+    }
 
     final inputBytes = inputData.toUint8List();
     _dictionary.setAll(initialSize, inputBytes);
@@ -154,20 +160,26 @@ class LzmaDecoder {
   // Decode [input] which contains compressed LZMA data that unpacks to
   // [uncompressedLength] bytes.
   Uint8List decode(InputStream input, int uncompressedLength) {
-    _rc.input = input;
+    _rc.setBuffer(input.toUint8List());
     _rc.initialize();
 
     // Expand dictionary to fit new data.
-    var initialSize = _dictionary.length;
-    var finalSize = initialSize + uncompressedLength;
-    final newDictionary = Uint8List(finalSize);
-    newDictionary.setAll(0, _dictionary);
-    _dictionary = newDictionary;
+    final initialSize = _writePosition;
+    final finalSize = initialSize + uncompressedLength;
+    if (finalSize > _dictionary.length) {
+      var newLen = _dictionary.isEmpty ? finalSize : _dictionary.length;
+      while (newLen < finalSize) newLen *= 2;
+      final newDictionary = Uint8List(newLen);
+      if (_writePosition > 0) {
+        newDictionary.setRange(0, _writePosition, _dictionary);
+      }
+      _dictionary = newDictionary;
+    }
 
     // Decode packets (literal, match or repeat) until all the data has been
     // decoded.
+    final positionMask = (1 << _positionBits) - 1;
     while (_writePosition < finalSize) {
-      final positionMask = (1 << _positionBits) - 1;
       final posState = _writePosition & positionMask;
       if (_rc.readBit(_nonLiteralTables[state.index], posState) == 0) {
         _decodeLiteral();
@@ -179,7 +191,7 @@ class LzmaDecoder {
     }
 
     // Return new data added to the dictionary.
-    return _dictionary.sublist(initialSize);
+    return _dictionary.sublist(initialSize, _writePosition);
   }
 
   // Returns true if the previous packet seen was a literal.
@@ -214,7 +226,7 @@ class LzmaDecoder {
 
     int value;
     if (_prevPacketIsLiteral()) {
-      value = _rc.readBittree(table, 8);
+      value = _rc.decodeByte(table.table, 0);
     } else {
       // Get the last byte before the match that just occurred.
       prevByte = _dictionary[_writePosition - _distance0 - 1];
@@ -332,16 +344,20 @@ class LzmaDecoder {
   // Repeat decompressed data, starting [distance] bytes back from the end of
   // the buffer and copying [length] bytes.
   void _repeatData(int distance, int length) {
-    final start = _writePosition - distance - 1;
-    for (var i = 0; i < length; i++) {
-      if (start < 0 || _writePosition < 0) {
-        break;
+    final src = _writePosition - distance - 1;
+    if (distance >= length) {
+      _dictionary.setRange(
+          _writePosition, _writePosition + length,
+          _dictionary, src);
+      _writePosition += length;
+    } else {
+      final end = _writePosition + length;
+      var s = src;
+      var d = _writePosition;
+      while (d < end) {
+        _dictionary[d++] = _dictionary[s++];
       }
-      _dictionary[_writePosition] = _dictionary[start + i];
-      _writePosition++;
-      /*if (_writePosition >= _dictionary.length) {
-        break; // TODO: what is this?
-      }*/
+      _writePosition = end;
     }
   }
 }

--- a/lib/src/codecs/lzma/lzma_decoder.dart
+++ b/lib/src/codecs/lzma/lzma_decoder.dart
@@ -84,10 +84,12 @@ class LzmaDecoder {
   }
 
   void trimDictionary(int maxSize) {
-    if (_writePosition <= maxSize) return;
-    final start = _writePosition - maxSize;
-    _dictionary = _dictionary.sublist(start, _writePosition);
-    _writePosition = maxSize;
+      final threshold = maxSize + (maxSize >> 2);
+      if (_writePosition <= threshold) return;
+  
+      final start = _writePosition - maxSize;
+      _dictionary.setRange(0, maxSize, _dictionary, start);
+      _writePosition = maxSize;
   }
 
   // Reset the decoder.

--- a/lib/src/codecs/lzma/lzma_decoder.dart
+++ b/lib/src/codecs/lzma/lzma_decoder.dart
@@ -23,6 +23,10 @@ class LzmaDecoder {
   // Number of bits used from [_dictionary] for literal probabilities.
   int _literalContextBits = 3;
 
+  // Cached masks
+  int _contextShift = 5;     // 8 - _literalContextBits
+  int _literalPosMask = 0;   // (1 << _literalPositionBits) - 1
+
   // Bit probabilities for determining which LZMA packet is present.
   final _nonLiteralTables = <RangeDecoderTable>[];
   late final RangeDecoderTable _repeatTable;
@@ -88,6 +92,9 @@ class LzmaDecoder {
     _positionBits = positionBits ?? _positionBits;
     _literalPositionBits = literalPositionBits ?? _literalPositionBits;
     _literalContextBits = literalContextBits ?? _literalContextBits;
+
+    _contextShift = 8 - _literalContextBits;
+    _literalPosMask = (1 << _literalPositionBits) - 1;
 
     state = _LzmaState.litLit;
     _distance0 = 0;
@@ -217,10 +224,9 @@ class LzmaDecoder {
   // Decode a packet containing a literal byte.
   void _decodeLiteral() {
     // Get probabilities based on previous byte written.
-    var prevByte = _writePosition > 0 ? _dictionary[_writePosition - 1] : 0;
-    final low = prevByte >> (8 - _literalContextBits);
-    final positionMask = (1 << _literalPositionBits) - 1;
-    final high = (_writePosition & positionMask) << _literalContextBits;
+    final prevByte = _writePosition > 0 ? _dictionary[_writePosition - 1] : 0;
+    final low = prevByte >> _contextShift;
+    final high = (_writePosition & _literalPosMask) << _literalContextBits;
     final hash = low + high;
     final table = _literalTables[hash];
 
@@ -228,28 +234,11 @@ class LzmaDecoder {
     if (_prevPacketIsLiteral()) {
       value = _rc.decodeByte(table.table, 0);
     } else {
-      // Get the last byte before the match that just occurred.
-      prevByte = _dictionary[_writePosition - _distance0 - 1];
-
-      value = 0;
-      var symbolPrefix = 1;
-      var matched = true;
-      final matchTable0 = _matchLiteralTables0[hash];
-      final matchTable1 = _matchLiteralTables1[hash];
-      for (var i = 0; i < 8; i++) {
-        int b;
-        if (matched) {
-          final matchBit = (prevByte >> 7) & 0x1;
-          prevByte <<= 1;
-          b = _rc.readBit(
-              matchBit == 0 ? matchTable0 : matchTable1, symbolPrefix | value);
-          matched = b == matchBit;
-        } else {
-          b = _rc.readBit(table, symbolPrefix | value);
-        }
-        value = (value << 1) | b;
-        symbolPrefix <<= 1;
-      }
+      value = _rc.decodeMatchedByte(
+          table.table, 0,
+          _matchLiteralTables0[hash].table,
+          _matchLiteralTables1[hash].table,
+          _dictionary[_writePosition - _distance0 - 1]);
     }
 
     // Add new byte to the output.

--- a/lib/src/codecs/lzma/lzma_decoder.dart
+++ b/lib/src/codecs/lzma/lzma_decoder.dart
@@ -165,7 +165,9 @@ class LzmaDecoder {
     final finalSize = initialSize + uncompressedLength;
     if (finalSize > _dictionary.length) {
       var newLen = _dictionary.isEmpty ? finalSize : _dictionary.length;
-      while (newLen < finalSize) newLen *= 2;
+      while (newLen < finalSize) {
+        newLen *= 2;
+      }
       final newDictionary = Uint8List(newLen);
       if (_writePosition > 0) {
         newDictionary.setRange(0, _writePosition, _dictionary);
@@ -191,7 +193,9 @@ class LzmaDecoder {
     final finalSize = initialSize + uncompressedLength;
     if (finalSize > _dictionary.length) {
       var newLen = _dictionary.isEmpty ? finalSize : _dictionary.length;
-      while (newLen < finalSize) newLen *= 2;
+      while (newLen < finalSize) {
+        newLen *= 2;
+      }
       final newDictionary = Uint8List(newLen);
       if (_writePosition > 0) {
         newDictionary.setRange(0, _writePosition, _dictionary);

--- a/lib/src/codecs/lzma/lzma_decoder.dart
+++ b/lib/src/codecs/lzma/lzma_decoder.dart
@@ -82,14 +82,21 @@ class LzmaDecoder {
 
     reset();
   }
-
+  
   void trimDictionary(int maxSize) {
       final threshold = maxSize + (maxSize >> 2);
       if (_writePosition <= threshold) return;
   
-      final start = _writePosition - maxSize;
-      _dictionary.setRange(0, maxSize, _dictionary, start);
-      _writePosition = maxSize;
+      final alignBits = _positionBits > _literalPositionBits
+          ? _positionBits
+          : _literalPositionBits;
+      final posMask = (1 << alignBits) - 1;
+      final alignment = _writePosition & posMask;
+      final keepBytes = maxSize + alignment;
+  
+      final start = _writePosition - keepBytes;
+      _dictionary.setRange(0, keepBytes, _dictionary, start);
+      _writePosition = keepBytes;
   }
 
   // Reset the decoder.

--- a/lib/src/codecs/lzma/lzma_decoder.dart
+++ b/lib/src/codecs/lzma/lzma_decoder.dart
@@ -61,6 +61,7 @@ class LzmaDecoder {
   // Decoded data, which is able to be copied.
   var _dictionary = Uint8List(0);
   var _writePosition = 0;
+  int dictionaryCap = 0;
 
   /// Creates an LZMA decoder.
   LzmaDecoder() {
@@ -168,6 +169,13 @@ class LzmaDecoder {
       while (newLen < finalSize) {
         newLen *= 2;
       }
+
+      if (dictionaryCap > 0 &&
+          newLen > dictionaryCap &&
+          dictionaryCap >= finalSize) {
+        newLen = dictionaryCap;
+      }
+
       final newDictionary = Uint8List(newLen);
       if (_writePosition > 0) {
         newDictionary.setRange(0, _writePosition, _dictionary);
@@ -196,6 +204,13 @@ class LzmaDecoder {
       while (newLen < finalSize) {
         newLen *= 2;
       }
+
+      if (dictionaryCap > 0 &&
+          newLen > dictionaryCap &&
+          dictionaryCap >= finalSize) {
+        newLen = dictionaryCap;
+      }
+
       final newDictionary = Uint8List(newLen);
       if (_writePosition > 0) {
         newDictionary.setRange(0, _writePosition, _dictionary);

--- a/lib/src/codecs/lzma/range_decoder.dart
+++ b/lib/src/codecs/lzma/range_decoder.dart
@@ -1,7 +1,5 @@
 import 'dart:typed_data';
 
-import '../../util/input_stream.dart';
-
 // Number of bits used for probabilities.
 const _probabilityBitCount = 11;
 
@@ -98,6 +96,52 @@ class RangeDecoder {
         code -= bound;
         probs[baseIndex + symbol] -= probs[baseIndex + symbol] >> 5;
         symbol = (symbol << 1) | 1;
+      }
+    }
+    return symbol & 0xff;
+  }
+
+
+  int decodeMatchedByte(Uint16List probs, int baseIndex,
+      Uint16List matchProbs0, Uint16List matchProbs1,
+      int matchByte) {
+    var symbol = 1;
+    var matched = true;
+    for (var i = 7; i >= 0; i--) {
+      if (range < 0x1000000) {
+        range <<= 8;
+        code = (code << 8) | _buffer[_bufferPos++];
+      }
+      if (matched) {
+        final matchBit = (matchByte >> i) & 1;
+        final t = matchBit == 0 ? matchProbs0 : matchProbs1;
+        final idx = symbol;
+        final bound = (range >> 11) * t[idx];
+        if (code < bound) {
+          range = bound;
+          t[idx] += (2048 - t[idx]) >> 5;
+          symbol = symbol << 1;
+          matched = matchBit == 0;
+        } else {
+          range -= bound;
+          code -= bound;
+          t[idx] -= t[idx] >> 5;
+          symbol = (symbol << 1) | 1;
+          matched = matchBit == 1;
+        }
+      } else {
+        final bound = (range >> 11) * probs[baseIndex + symbol];
+        if (code < bound) {
+          range = bound;
+          probs[baseIndex + symbol] +=
+              (2048 - probs[baseIndex + symbol]) >> 5;
+          symbol = symbol << 1;
+        } else {
+          range -= bound;
+          code -= bound;
+          probs[baseIndex + symbol] -= probs[baseIndex + symbol] >> 5;
+          symbol = (symbol << 1) | 1;
+        }
       }
     }
     return symbol & 0xff;

--- a/lib/src/codecs/lzma/range_decoder.dart
+++ b/lib/src/codecs/lzma/range_decoder.dart
@@ -29,9 +29,6 @@ class RangeDecoderTable {
 
 /// Implements the LZMA range decoder for [LZMADecoder].
 class RangeDecoder {
-  // Data being read from.
-  late InputStream _input;
-
   // Mask showing the current bits in [code].
   var range = 0xffffffff;
 

--- a/lib/src/codecs/lzma/range_decoder.dart
+++ b/lib/src/codecs/lzma/range_decoder.dart
@@ -38,10 +38,14 @@ class RangeDecoder {
   // Current code being stored.
   var code = 0;
 
+  Uint8List _buffer = Uint8List(0);
+  int _bufferPos = 0;
+
   // Set the input being read from. Must be set before initializing or reading
   // bits.
-  set input(InputStream value) {
-    _input = value;
+  void setBuffer(Uint8List data) {
+    _buffer = data;
+    _bufferPos = 0;
   }
 
   void reset() {
@@ -52,33 +56,54 @@ class RangeDecoder {
   void initialize() {
     code = 0;
     range = 0xffffffff;
-    // Skip the first byte, then load four for the initial state.
-    _input.skip(1);
+    _bufferPos++;
     for (var i = 0; i < 4; i++) {
-      code = (code << 8 | _input.readByte());
+      code = (code << 8) | _buffer[_bufferPos++];
     }
   }
 
   // Read a single bit from the decoder, using the supplied [index] into a
   // probabilities [table].
   int readBit(RangeDecoderTable table, int index) {
-    _load();
-
+    if (range < 0x1000000) {
+      range <<= 8;
+      code = (code << 8) | _buffer[_bufferPos++];
+    }
     final p = table.table[index];
-    final bound = (range >> _probabilityBitCount) * p;
-    const moveBits = 5;
+    final bound = (range >> 11) * p;
     if (code < bound) {
       range = bound;
-      final oneMinusP = _probabilityOne - p;
-      final shifted = oneMinusP >> moveBits;
-      table.table[index] += shifted;
+      table.table[index] += (2048 - p) >> 5;
       return 0;
     } else {
       range -= bound;
       code -= bound;
-      table.table[index] -= p >> moveBits;
+      table.table[index] -= p >> 5;
       return 1;
     }
+  }
+
+  int decodeByte(Uint16List probs, int baseIndex) {
+    var symbol = 1;
+    for (var i = 0; i < 8; i++) {
+      if (range < 0x1000000) {
+        range <<= 8;
+        code = (code << 8) | _buffer[_bufferPos++];
+      }
+      final bound = (range >> 11) * probs[baseIndex + symbol];
+      if (code < bound) {
+        range = bound;
+        probs[baseIndex + symbol] +=
+            (2048 - probs[baseIndex + symbol]) >> 5;
+        symbol = symbol << 1;
+      } else {
+        range -= bound;
+        code -= bound;
+        probs[baseIndex + symbol] -= probs[baseIndex + symbol] >> 5;
+        symbol = (symbol << 1) | 1;
+      }
+    }
+    return symbol & 0xff;
   }
 
   // Read a bittree (big endian) of [count] bits from the decoder.
@@ -111,7 +136,10 @@ class RangeDecoder {
   int readDirect(int count) {
     var value = 0;
     for (var i = 0; i < count; i++) {
-      _load();
+      if (range < 0x1000000) {
+        range <<= 8;
+        code = (code << 8) | _buffer[_bufferPos++];
+      }
       range >>= 1;
       code -= range;
       value <<= 1;
@@ -121,16 +149,6 @@ class RangeDecoder {
         value++;
       }
     }
-
     return value;
-  }
-
-  // Load a byte if we can fit it.
-  void _load() {
-    const topValue = 1 << 24;
-    if (range < topValue) {
-      range <<= 8;
-      code = (code << 8) | _input.readByte();
-    }
   }
 }

--- a/lib/src/codecs/xz_decoder.dart
+++ b/lib/src/codecs/xz_decoder.dart
@@ -161,7 +161,9 @@ class _XZStreamDecoder {
       //throw ArchiveException('Invalid block CRC checksum');
     }
 
-    if (filters.length != 2 && filters.first != 0x21) {
+    // We must abort if there is more than one filter   
+    // (length != 2) or if the filter is not LZMA2 (first != 0x21).
+    if (filters.length != 2 || filters.first != 0x21) {
       return false;
       //throw ArchiveException('Unsupported filters');
     }
@@ -411,8 +413,9 @@ class _XZStreamDecoder {
       //throw ArchiveException('Invalid stream footer CRC checksum');
     }
 
+    // The stream is invalid if at least one byte is corrupted.
     final magic = input.readBytes(2).toUint8List();
-    if (magic[0] != 89 /* 'Y' */ && magic[1] != 90 /* 'Z' */) {
+    if (magic[0] != 89 /* 'Y' */ || magic[1] != 90 /* 'Z' */) {
       return false;
       //throw ArchiveException('Invalid XZ stream footer signature');
     }

--- a/lib/src/codecs/xz_decoder.dart
+++ b/lib/src/codecs/xz_decoder.dart
@@ -294,6 +294,7 @@ class _XZStreamDecoder {
           final length = (input.readByte() << 8 | input.readByte()) + 1;
           output.writeBytes(
               decoder.decodeUncompressed(input.readBytes(length), length));
+          decoder.trimDictionary(dictionarySize);
         } else {
           return false;
           //throw ArchiveException('Unknown LZMA2 control code $control');
@@ -331,6 +332,7 @@ class _XZStreamDecoder {
 
         output.writeBytes(decoder.decode(
             input.readBytes(compressedLength), uncompressedLength));
+        decoder.trimDictionary(dictionarySize);
       }
     }
 

--- a/lib/src/codecs/xz_decoder.dart
+++ b/lib/src/codecs/xz_decoder.dart
@@ -1,6 +1,7 @@
 import 'dart:typed_data';
 
 import '../util/crc32.dart';
+import '../util/crc64.dart';
 import '../util/input_memory_stream.dart';
 import '../util/input_stream.dart';
 import '../util/output_memory_stream.dart';
@@ -121,6 +122,7 @@ class _XZStreamDecoder {
 
     final filters = <int>[];
     var dictionarySize = 0;
+
     for (var i = 0; i < nFilters; i++) {
       final id = _readMultibyteInteger(header);
       final propertiesLength = _readMultibyteInteger(header);
@@ -150,6 +152,12 @@ class _XZStreamDecoder {
         filters.add(0);
       }
     }
+
+    if (dictionarySize > 0 && dictionarySize < 0x40000000) {
+      decoder.dictionaryCap =
+          dictionarySize + (dictionarySize >> 2) + (2 << 20) + 16;
+    }
+
     if (_readPadding(header) < 0) {
       return false;
     }
@@ -199,13 +207,10 @@ class _XZStreamDecoder {
       case 0: // none
         break;
       case 0x1: // CRC32
-        /*final expectedCrc =*/ input.readUint32();
-        /*if (verify) {
-          final actualCrc = getCrc32(data.toBytes().sublist(startDataLength));
-          if (actualCrc != expectedCrc) {
-            throw ArchiveException('CRC32 check failed');
-          }
-        }*/
+        final int expectedCrc = input.readUint32();
+        if (verify && getCrc32(output.subset(startDataLength)) != expectedCrc) {
+          return false;
+        }
         break;
       case 0x2:
       case 0x3:
@@ -215,13 +220,12 @@ class _XZStreamDecoder {
         }*/
         break;
       case 0x4: // CRC64
-        /*final expectedCrc =*/ input.readUint64();
-        /*if (verify && isCrc64Supported()) {
-          final actualCrc = getCrc64(data.toBytes().sublist(startDataLength));
-          if (actualCrc != expectedCrc) {
-            throw ArchiveException('CRC64 check failed');
-          }
-        }*/
+        final int expectedCrc = input.readUint64();
+        if (verify &&
+            isCrc64Supported() &&
+            getCrc64(output.subset(startDataLength)) != expectedCrc) {
+          return false;
+        }
         break;
       case 0x5:
       case 0x6:

--- a/lib/src/codecs/xz_decoder.dart
+++ b/lib/src/codecs/xz_decoder.dart
@@ -287,8 +287,11 @@ class _XZStreamDecoder {
           decoder.reset(resetDictionary: true);
           return true;
         } else if (control == 1) {
+          decoder.reset(resetDictionary: true);
           final length = (input.readByte() << 8 | input.readByte()) + 1;
-          output.writeBytes(input.readBytes(length).toUint8List());
+          output.writeBytes(
+              decoder.decodeUncompressed(input.readBytes(length), length));
+          decoder.trimDictionary(dictionarySize);
         } else if (control == 2) {
           // uncompressed data
           final length = (input.readByte() << 8 | input.readByte()) + 1;

--- a/lib/src/codecs/xz_decoder.dart
+++ b/lib/src/codecs/xz_decoder.dart
@@ -64,7 +64,8 @@ class _XZStreamDecoder {
       }
     }
 
-    return true;
+    // Valid XZ always goes trough _readStreamFooter
+    return false;
   }
 
   // Reads an XZ steam header from [input].
@@ -168,7 +169,7 @@ class _XZStreamDecoder {
     final startPosition = input.position;
     final startDataLength = output.length;
 
-    _readLZMA2(input, output, dictionarySize);
+    if (!_readLZMA2(input, output, dictionarySize)) return false;
 
     final actualCompressedLength = input.position - startPosition;
     final actualUncompressedLength = output.length - startDataLength;
@@ -339,7 +340,8 @@ class _XZStreamDecoder {
       }
     }
 
-    return true;
+    // 00000000 - end marker, if not reached - there's an issue with file
+    return false;
   }
 
   // Reads an XZ stream index from [input].

--- a/lib/src/util/_crc64_io.dart
+++ b/lib/src/util/_crc64_io.dart
@@ -1,19 +1,11 @@
-// Works around Dart treating 64 bit integers as signed when shifting.
-int shiftDown64(int value) {
-  if (value & 0x8000000000000000 == 0) {
-    return value >> 8;
-  }
-  return (value & 0x7fffffffffffffff) >> 8 | 0x0080000000000000;
-}
-
 bool isCrc64Supported_() => true;
 
 /// Get the CRC-64 checksum of the given array. You can append bytes to an
 /// already computed crc by specifying the previous [crc] value.
 int getCrc64_(List<int> array, [int crc = 0]) {
   crc ^= 0xffffffffffffffff;
-  for (var e in array) {
-    crc = _crc64Table[(crc & 0xff) ^ e] ^ shiftDown64(crc);
+  for (int i = 0; i < array.length; i++) {
+    crc = _crc64Table[(crc & 0xff) ^ array[i]] ^ (crc >>> 8);
   }
   return crc ^ 0xffffffffffffffff;
 }


### PR DESCRIPTION
### Bugfix:
Previous version of XZDecoder had 1 bug - 1 means that dictionary has to be reset, but it never reset it
```dart
} else if (control == 1) {
    // <- dictionary is never reset!
    final length = (input.readByte() << 8 | input.readByte()) + 1;
    output.writeBytes(input.readBytes(length).toUint8List());
}
```

### Ram improvements:
Dictionary now never grows with file, it's limited to max dictionary size + 25% for optimization since this is how the algorithm works, it does not read from memory that is beyond max size (new **trimDictionary** function)

### Speed improvement:
My test that compared XZ with Gzip on 3 different files shows ~47% increase in speed in release mode on MacOS

Default (no changes):
```dart
flutter: File                                       Format   Compressed Unpack     Time         MB/s
flutter: ───────────────────────────────────────────────────────────────────────────────────────────────
flutter: 1_file.dll                                 gzip     2.6 MB     6.3 MB     10 ms        582.5
flutter:                                            xz       1.9 MB     6.3 MB     165 ms       38.4  (x15.2 vs gzip)
flutter: 
flutter: 2_file.dll                                 gzip     1.5 MB     2.6 MB     4 ms         566.1
flutter:                                            xz       1.3 MB     2.6 MB     86 ms        30.0  (x18.8 vs gzip)
flutter: 
flutter: 3_file.dll                                 gzip     11.2 MB    26.0 MB    44 ms        578.7
flutter:                                            xz       8.2 MB     26.0 MB    778 ms       33.4  (x17.3 vs gzip)
flutter: 
```

After change:
```dart
flutter: 
flutter: File                                       Format   Compressed Unpack     Time         MB/s
flutter: ───────────────────────────────────────────────────────────────────────────────────────────────
flutter: 1_file.dll                                 gzip     2.6 MB     6.3 MB     10 ms        601.6
flutter:                                            xz       1.9 MB     6.3 MB     117 ms       54.2  (x11.1 vs gzip)
flutter: 
flutter: 2_file.dll                                 gzip     1.5 MB     2.6 MB     4 ms         562.3
flutter:                                            xz       1.3 MB     2.6 MB     57 ms        45.0  (x12.5 vs gzip)
flutter: 
flutter: 3_file.dll                                 gzip     11.2 MB    26.0 MB    45 ms        573.5
flutter:                                            xz       8.2 MB     26.0 MB    489 ms       53.2  (x10.8 vs gzip)
flutter: 
flutter: 4_file.dll                                 gzip     1082.2 MB  1114.1 MB  1.59 sec     702.7
flutter:                                            xz       1070.8 MB  1114.1 MB  19.83 sec    56.2  (x12.5 vs gzip)
flutter: 
```

> Large file (4) was impossible to test on current version of package because it has 1 bug related to dictionary reset in control == 1

The only difference in code is error for broken archives - old code, as far as i understand, threw and error from InputStream.readByte like "end of stream" and new one will throw RangeError: index out of range. But those are both unhandled exceptions so it shouldn't affect anything.

This is how test was performed:
```dart
import 'dart:io';
import 'dart:isolate';
import 'dart:typed_data';
import 'package:archive/archive.dart';

void main() async {
  const dir = '/Users/test/Downloads';
  final files = ['1_file.dll', '2_file.dll', '3_file.dll', '4_file.dll'];

  print('');
  print(
    '${'File'.padRight(42)} ${'Format'.padRight(8)} '
        '${'Compressed'.padRight(10)} ${'Unpack'.padRight(10)} '
        '${'Time'.padRight(12)} MB/s',
  );
  print('─' * 95);

  for (final name in files) {
    final gzPath = '$dir/gzip_$name.gz';
    final xzPath = '$dir/xz_$name.xz';
    final gzBytes = File(gzPath).readAsBytesSync();
    final xzBytes = File(xzPath).readAsBytesSync();

    final gzResult = await Isolate.run(() => _bench(gzBytes, 'gzip'));
    print(
      '${name.padRight(42)} ${'gzip'.padRight(8)} '
          '${_fmtSize(gzBytes.length).padRight(10)} '
          '${_fmtSize(gzResult.unpackedSize).padRight(10)} '
          '${_fmtDuration(gzResult.bestTime).padRight(12)} '
          '${gzResult.mbps.toStringAsFixed(1)}',
    );

    final xzResult = await Isolate.run(() => _bench(xzBytes, 'xz'));
    final ratio = xzResult.bestTime.inMicroseconds / gzResult.bestTime.inMicroseconds;
    print(
      '${''.padRight(42)} ${'xz'.padRight(8)} '
          '${_fmtSize(xzBytes.length).padRight(10)} '
          '${_fmtSize(xzResult.unpackedSize).padRight(10)} '
          '${_fmtDuration(xzResult.bestTime).padRight(12)} '
          '${xzResult.mbps.toStringAsFixed(1)}'
          '  (x${ratio.toStringAsFixed(1)} vs gzip)',
    );
    print('');
  }
}

_BenchResult _bench(Uint8List compressed, String format) {
  final large = compressed.length > 100 * 1024 * 1024;
  final runs = 1;

  // Warmup
  if (!large) {
    _decompress(compressed, format);
  }

  var best = const Duration(days: 1);
  late Uint8List result;
  for (var i = 0; i < runs; i++) {
    final sw = Stopwatch()..start();
    result = _decompress(compressed, format);
    sw.stop();
    if (sw.elapsed < best) best = sw.elapsed;
  }

  final mbps = result.length / 1024 / 1024 / (best.inMicroseconds / 1e6);
  return _BenchResult(best, result.length, mbps);
}

Uint8List _decompress(Uint8List bytes, String format) {
  if (format == 'gzip') {
    return Uint8List.fromList(const GZipDecoder().decodeBytes(bytes));
  } else {
    return XZDecoder().decodeBytes(bytes);
  }
}

class _BenchResult {
  final Duration bestTime;
  final int unpackedSize;
  final double mbps;
  _BenchResult(this.bestTime, this.unpackedSize, this.mbps);
}

String _fmtSize(int bytes) {
  if (bytes >= 1024 * 1024) {
    return '${(bytes / 1024 / 1024).toStringAsFixed(1)} MB';
  }
  return '${(bytes / 1024).toStringAsFixed(0)} KB';
}

String _fmtDuration(Duration d) {
  if (d.inMilliseconds < 1) return '${d.inMicroseconds} us';
  if (d.inMilliseconds < 1000) return '${d.inMilliseconds} ms';
  return '${(d.inMicroseconds / 1e6).toStringAsFixed(2)} sec';
}
```